### PR TITLE
chore: add release plz pipeline

### DIFF
--- a/.github/workflows/release-plz.toml
+++ b/.github/workflows/release-plz.toml
@@ -1,0 +1,65 @@
+name: Release-plz (Bindings)
+
+on:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-plz-pr:
+    if: ${{ github.repository_owner == 'Unleash' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: App token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
+          private-key: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app.outputs.token }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: release-plz (release-pr)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app.outputs.token }}
+
+  release-plz-release:
+    if: ${{ github.repository_owner == 'Unleash' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: App token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
+          private-key: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app.outputs.token }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: release-plz (release)
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ steps.app.outputs.token }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,102 @@
+[workspace]
+
+changelog_update = true
+
+dependencies_update = true
+
+git_tag_enable = true
+
+git_release_enable = true
+
+pr_labels = ["release"]
+
+allow_dirty = false
+
+publish_allow_dirty = false
+
+semver_check = true
+
+[changelog]
+
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^dep-update", group = "<!-- 11 --> Dependency updates" },
+    { message = "^build\\(deps\\)", group = "<!-- 11 --> Dependency updates" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { message = ".*", group = "<!-- 10 -->💼 Other" },
+]
+
+commit_preprocessors = [
+    # Replace `<REPO>` in the template body with the repository URL
+    { pattern = '<REPO>', replace = "https://github.com/unleash/unleash-edge" },
+
+    # Replace multiple spaces with a single space.
+    { pattern = "  +", replace = " " },
+
+    # Replace the issue number with the link.
+    { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/unleash/unleash-edge/issues/${1}))" },
+    # Remove prefix
+    { pattern = 'Merged PR #[0-9]: (.*)', replace = "$1" },
+
+    # Remove gitmoji from commit messages, both actual UTF emoji and :emoji:
+    { pattern = ' *(:\w+:|[\p{Emoji_Presentation}\p{Extended_Pictographic}\u{200D}]) *', replace = "" },
+
+    # Hyperlink PR references from merge commits.
+    { pattern = "Merge pull request #([0-9]+) from [^ ]+", replace = "PR # [${1}](https://github.com/unleash/unleash-edge/pull/${1}):" },
+
+    # Hyperlink commit links, with short commit hash as description.
+    { pattern = "https://github.com/unleash/unleash-edge/commit/([a-f0-9]{7})[a-f0-9]*", replace = "commit # [${1}](${0})" },
+
+    # Linear issue references
+    { pattern = "\\(([0-9]-[0-9]+)\\)", replace = "Linear issue: [${1}](https://linear.app/unleash/issue/${1})"},
+
+    # Hyperlink bare commit hashes like "abcd1234" in commit logs, with short commit hash as description.
+    { pattern = "([ \\n])(([a-f0-9]{7})[a-f0-9]*)", replace = "${1}commit # [${3}](https://github.com/unleash/unleash-edge/commit/${2})" },
+]
+
+body = """
+
+## [{{ version | trim_start_matches(pat="v") }}]\
+    {%- if release_link -%}\
+        ({{ release_link }})\
+    {% endif %} \
+    - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        {%- if commit.scope -%}
+            - *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}\
+                {{ commit.message }}{{ self::username(commit=commit) }}\
+                {%- if commit.links %} \
+                    ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%})\
+                {% endif %}
+        {% else -%}
+            - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{{ self::username(commit=commit) }}{{ self::pr(commit=commit) }}
+        {% endif -%}
+    {% endfor -%}
+{% endfor %}
+{%- if remote.contributors %}
+### Contributors
+{% for contributor in remote.contributors %}
+    * @{{ contributor.username }}
+{%- endfor %}
+{% endif -%}
+{%- macro username(commit) -%}
+    {% if commit.remote.username %} (by @{{ commit.remote.username }}){% endif -%}
+{% endmacro -%}
+{%- macro pr(commit) -%}
+    {% if commit.remote.pr_number %} - #{{ commit.remote.pr_number }}{% endif -%}
+{% endmacro -%}
+"""


### PR DESCRIPTION
Adds a release plz pipeline. This is only responsible for generating the github release and tagging the repo. Another pipeline picks up the tag and generates the binaries and there's no publishable artifact here since this project is pure bindings