### PR TITLE
chore: allow null custom strategy results

### DIFF
--- a/yggdrasilffi/src/lib.rs
+++ b/yggdrasilffi/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     ffi::{c_char, c_void, CStr, CString},
     fmt::{self, Display, Formatter},
     mem::forget,
@@ -28,7 +29,7 @@ struct Response<T> {
 
 type RawPointerDataType = Mutex<EngineState>;
 type ManagedEngine = Arc<RawPointerDataType>;
-type CustomStrategyResults = std::collections::HashMap<String, bool>;
+type CustomStrategyResults = HashMap<String, bool>;
 
 #[derive(Serialize, Deserialize, PartialEq, Eq)]
 enum ResponseCode {


### PR DESCRIPTION
Allowing custom_strategy_results to be null gives callers two wins:
1. They no longer have to marshal and pass an empty JSON object when they have no bespoke strategies, so a common fast path avoids extra allocations and parsing; 
2. The FFI stops treating “no custom results” as an error and instead mirrors the Rust engine’s own `Option<HashMap<…>>` contract, which makes the boundary more robust against mistakes. 

**Net result:** less CPU on every evaluation without custom strategies and fewer crash-prone edge cases.

- Accept NULL for custom_strategy_results so SDK callers without bespoke strategies avoid JSON marshaling.
- Share a helper that unwraps strategy results only when a pointer is provided, trimming unnecessary parsing overhead.