### PR TITLE
fix(java): fix test by supporting isBeforeOrEqual

### DIFF
--- a/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/UnleashEngineTest.java
@@ -448,7 +448,7 @@ class UnleashEngineTest {
     Instant stop = bucket.getStop();
     ZonedDateTime utcStop = stop.atZone(ZoneOffset.UTC);
 
-    assertThat(utcStart).isBeforeOrEqualTo (now);
+    assertThat(utcStart).isBeforeOrEqualTo(now);
     assertThat(utcStart.plusMinutes(1)).isAfter(now);
     assertThat(utcStop).isBeforeOrEqualTo(now);
     assertThat(utcStop.plusMinutes(1)).isAfter(now);


### PR DESCRIPTION
Seems like we've been lucky earlier with it never running on the exact same millisecond. This test tolerates before as well.