### PR TITLE
fix: update CI to use upload and download artifact actions

### DIFF
--- a/.github/workflows/release-new-ffi-version.yaml
+++ b/.github/workflows/release-new-ffi-version.yaml
@@ -161,6 +161,7 @@ jobs:
 
   upload_to_release:
     needs:
+      - create-tag-and-release
       - build
     runs-on: ubuntu-latest
     steps:
@@ -178,6 +179,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          TAG="${{ create-tag-and-release.outputs.full_tag }}"
+          TAG="${{ needs.create-tag-and-release.outputs.full_tag }}"
           gh release upload "$TAG" assets/* --clobber
 


### PR DESCRIPTION
Simplifies build script to use upload-artifact and download artifact workflow. Also uses gh release upload