### PR TITLE
chore: bump dotnet engine to ygg 0.18.2

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.1.1-beta.0</Version>
     <YggdrasilCoreVersion>0.18.2</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>


### PR DESCRIPTION
This bumps the .NET engine to Yggdrasil v 0.18.2 (with flatbuffer over FFI support)