### PR TITLE
chore(dotnet): make publish action download and embed more like the java publish action

### DIFF
--- a/.github/workflows/publish-dotnet.yaml
+++ b/.github/workflows/publish-dotnet.yaml
@@ -24,44 +24,13 @@ jobs:
           echo "FFI Library Version: $CORE_VERSION"
           echo "CORE_VERSION=$CORE_VERSION" >> $GITHUB_ENV
 
-      - name: Download and Organize Binaries
+      - name: Download binaries
+        shell: bash
+        working-directory: ./dotnet-engine
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          binaries=("libyggdrasilffi_x86_64-musl.so dotnet-engine/runtimes/linux-musl-x64/native"
-                    "libyggdrasilffi_arm64-musl.so dotnet-engine/runtimes/linux-musl-arm64/native"
-                    "libyggdrasilffi_arm64.so dotnet-engine/runtimes/linux-arm64/native"
-                    "libyggdrasilffi_x86_64.so dotnet-engine/runtimes/linux-x64/native"
-                    "yggdrasilffi_arm64.dll dotnet-engine/runtimes/win-arm64/native"
-                    "yggdrasilffi_x86_64.dll dotnet-engine/runtimes/win-x64/native"
-                    "yggdrasilffi_i686.dll dotnet-engine/runtimes/win-x86/native"
-                    "libyggdrasilffi_arm64.dylib dotnet-engine/runtimes/osx-arm64/native"
-                    "libyggdrasilffi_x86_64.dylib dotnet-engine/runtimes/osx-x64/native")
-
-          for binary in "${binaries[@]}"; do
-            # Split each item into source (release name) and target path
-            src_name=$(echo "$binary" | awk '{print $1}')
-            target_path=$(echo "$binary" | awk '{print $2}')
-
-            echo "Downloading $src_name to $target_path..."
-
-            mkdir -p "$target_path"
-
-            curl -L -o "$target_path/$src_name" \
-              -H "Authorization: token $GITHUB_TOKEN" \
-              "https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
-
-            echo "Downloaded from https://github.com/${{ github.repository }}/releases/download/unleash-yggdrasil-v${CORE_VERSION}/${src_name}"
-
-            if [ -f "$target_path/$src_name" ]; then
-              echo "$src_name downloaded successfully to $target_path."
-            else
-              echo "Error: $src_name could not be downloaded to $target_path."
-              exit 1
-            fi
-            ls -l "$target_path"
-          done
-          echo "Downloaded binaries"
+          gh release download "yggdrasilffi-v$CORE_VERSION" --repo Unleash/yggdrasil-bindings -D binaries/
 
       - name: Build
         run: |

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -55,31 +55,31 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="../runtimes/win-x64/native/yggdrasilffi_x86_64.dll" Condition="Exists('../runtimes/win-x64/native/yggdrasilffi_x86_64.dll')">
+    <EmbeddedResource Include="../binaries/yggdrasilffi_x86_64.dll" Condition="Exists('../binaries/yggdrasilffi_x86_64.dll')">
       <LogicalName>Yggdrasil.Engine.yggdrasilffi_x86_64_$(YggdrasilCoreVersion).dll</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/win-arm64/native/yggdrasilffi_arm64.dll" Condition="Exists('../runtimes/win-arm64/native/yggdrasilffi_arm64.dll')">
+    <EmbeddedResource Include="../binaries/yggdrasilffi_arm64.dll" Condition="Exists('../binaries/yggdrasilffi_arm64.dll')">
       <LogicalName>Yggdrasil.Engine.yggdrasilffi_arm64_$(YggdrasilCoreVersion).dll</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/win-x86/native/yggdrasilffi_i686.dll" Condition="Exists('../runtimes/win-x86/native/yggdrasilffi_i686.dll')">
+    <EmbeddedResource Include="../binaries/yggdrasilffi_i686.dll" Condition="Exists('../binaries/yggdrasilffi_i686.dll')">
       <LogicalName>Yggdrasil.Engine.yggdrasilffi_i686_$(YggdrasilCoreVersion).dll</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so" Condition="Exists('../runtimes/linux-x64/native/libyggdrasilffi_x86_64.so')">
+    <EmbeddedResource Include="../binaries/libyggdrasilffi_x86_64.so" Condition="Exists('../binaries/libyggdrasilffi_x86_64.so')">
       <LogicalName>Yggdrasil.Engine.libyggdrasilffi_x86_64_$(YggdrasilCoreVersion).so</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so" Condition="Exists('../runtimes/linux-arm64/native/libyggdrasilffi_arm64.so')">
+    <EmbeddedResource Include="../binaries/libyggdrasilffi_arm64.so" Condition="Exists('../binaries/libyggdrasilffi_arm64.so')">
       <LogicalName>Yggdrasil.Engine.libyggdrasilffi_arm64_$(YggdrasilCoreVersion).so</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl.so" Condition="Exists('../runtimes/linux-musl-x64/native/libyggdrasilffi_x86_64-musl.so')">
+    <EmbeddedResource Include="../binaries/libyggdrasilffi_x86_64-musl.so" Condition="Exists('../binaries/libyggdrasilffi_x86_64-musl.so')">
       <LogicalName>Yggdrasil.Engine.libyggdrasilffi_x86_64-musl_$(YggdrasilCoreVersion).so</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl.so" Condition="Exists('../runtimes/linux-musl-arm64/native/libyggdrasilffi_arm64-musl.so')">
+    <EmbeddedResource Include="../binaries/libyggdrasilffi_arm64-musl.so" Condition="Exists('../binaries/libyggdrasilffi_arm64-musl.so')">
       <LogicalName>Yggdrasil.Engine.libyggdrasilffi_arm64-musl_$(YggdrasilCoreVersion).so</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib" Condition="Exists('../runtimes/osx-x64/native/libyggdrasilffi_x86_64.dylib')">
+    <EmbeddedResource Include="../binaries/libyggdrasilffi_x86_64.dylib" Condition="Exists('../binaries/libyggdrasilffi_x86_64.dylib')">
       <LogicalName>Yggdrasil.Engine.libyggdrasilffi_x86_64_$(YggdrasilCoreVersion).dylib</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib" Condition="Exists('../runtimes/osx-arm64/native/libyggdrasilffi_arm64.dylib')">
+    <EmbeddedResource Include="../binaries/libyggdrasilffi_arm64.dylib" Condition="Exists('../binaries/libyggdrasilffi_arm64.dylib')">
       <LogicalName>Yggdrasil.Engine.libyggdrasilffi_arm64_$(YggdrasilCoreVersion).dylib</LogicalName>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
Changes the dotnet publishing to download in the same fashion as java does - to the binaries folder, then include from there rather than from separate folders in the csproj build section