### PR TITLE
chore(dotnet): bump beta verison to release with the updated workflow

### DIFF
--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.1.1-beta.0</Version>
+    <Version>1.1.1-beta.1</Version>
     <YggdrasilCoreVersion>0.18.2</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>


### PR DESCRIPTION
Set up for releasing a beta.1 version of the ygg flatbuffers enabled .NET SDK with the updated workflow so we can remove the .0 version that didn't include assemblies