### PR TITLE
chore: update publish ruby task after move

### DIFF
--- a/.github/workflows/publish-ruby.yaml
+++ b/.github/workflows/publish-ruby.yaml
@@ -58,7 +58,7 @@ jobs:
             exit 1
           fi
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
 
       - name: Build Gem
         run: |


### PR DESCRIPTION
Updated the workflow to download the binaries using `gh` CLI, extracting versions once.