### PR TITLE
chore: added upload artifact task to workflow

### DIFF
--- a/.github/workflows/build-rust-binaries.yaml
+++ b/.github/workflows/build-rust-binaries.yaml
@@ -91,3 +91,8 @@ jobs:
         run: cargo zigbuild -p yggdrasilffi --release --target ${{ matrix.target }}
         env:
           ZIG_TARGET: ${{ matrix.zigTarget }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.name }}
+          path: release/target/${{ matrix.output }}

--- a/.github/workflows/build-rust-binaries.yaml
+++ b/.github/workflows/build-rust-binaries.yaml
@@ -95,4 +95,4 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.name }}
-          path: release/target/${{ matrix.output }}
+          path: release/target/${{ matrix.target }}/${{ matrix.output }}


### PR DESCRIPTION
This adds upload-artifact to the build-rust-binaries workflow, which will make it possible to download the binaries.

build-rust-binaries is not the workflow that does the release, but is a copy that allowed us to test the build flow without having to release a new version of the library to test the compilation across the entire matrix of supported platforms.