### PR TITLE
feat: bump engine for cidr and semver constraints

### DIFF
--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Unleash/client-specification
-          ref: v5.2.2
+          ref: v6.1.0
           path: client-specification
 
       - name: Setup Java

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Unleash/client-specification
-          ref: v5.2.2
+          ref: v6.1.0
           path: client-specification
 
       - name: Run cargo tests

--- a/.github/workflows/build-ruby.yml
+++ b/.github/workflows/build-ruby.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: Unleash/client-specification
-          ref: v5.2.2
+          ref: v6.1.0
           path: client-specification
 
       - name: Run cargo tests

--- a/.github/workflows/sarif-and-test.yaml
+++ b/.github/workflows/sarif-and-test.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: Unleash/client-specification
-          ref: v5.2.2
+          ref: v6.1.0
           path: client-specification
       - name: Run tests
         run: |

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -6,8 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
-    <Version>1.2.1</Version>
-    <YggdrasilCoreVersion>0.20.5</YggdrasilCoreVersion>
+    <Version>1.3.0</Version>
+    <YggdrasilCoreVersion>0.20.6</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>
     <IncludeSymbols>True</IncludeSymbols>

--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,5 +1,5 @@
 group=io.getunleash
-yggdrasilCoreVersion=0.20.5
-version=0.5.2
-clientSpecificationVersion=5.2.2
+yggdrasilCoreVersion=0.20.6
+version=1.0.0
+clientSpecificationVersion=6.1.0
 clientSpecificationUrlTemplate=https://github.com/Unleash/client-specification/archive/refs/tags/v%s.zip

--- a/python-engine/pyproject.toml
+++ b/python-engine/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yggdrasil-engine"
-version = "1.2.3"
+version = "1.3.0"
 description = "Engine for evaluating Unleash feature flags"
 authors = ["Simon Hornby <liquidwicked64@gmail.com>"]
 license = "MIT"

--- a/python-engine/yggdrasil_engine/__init__.py
+++ b/python-engine/yggdrasil_engine/__init__.py
@@ -1,1 +1,1 @@
-__yggdrasil_core_version__ = "0.20.5"
+__yggdrasil_core_version__ = "0.20.6"

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   target_platform = -> { ENV['YGG_BUILD_PLATFORM'] || Gem::Platform::CURRENT }
 
   s.name = 'yggdrasil-engine'
-  s.version = '1.2.2'
+  s.version = '1.3.0'
   s.summary = 'Unleash engine for evaluating feature toggles'
   s.description = '...'
   s.authors = ['Unleash']
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.add_dependency "ffi", "~> 1.17.2"
   s.platform = target_platform.call
-  s.metadata["yggdrasil_core_version"] = '0.20.5'
+  s.metadata["yggdrasil_core_version"] = '0.20.6'
 end

--- a/yggdrasilffi/Cargo.toml
+++ b/yggdrasilffi/Cargo.toml
@@ -16,5 +16,5 @@ jni = { version = "0.21.1" }
 serde_json = "1.0.135"
 serde = { version = "1.0.217", features = ["derive"] }
 unleash-types = { version = "0.15.21", default-features = false }
-unleash-yggdrasil = { version = "0.21.0" }
+unleash-yggdrasil = { version = "0.21.1" }
 flatbuffers = "25.2.10"


### PR DESCRIPTION
Takes Java up to 1.0.0, it's overdue