### PR TITLE
feat(dotnet): fix AOT compilation blockers in Yggdrasil .NET Engine

### DIFF
--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
 
       - name: Restore dependencies
         run: |
@@ -94,3 +94,21 @@ jobs:
         run: |
           cd dotnet-engine/Yggdrasil.Engine.Tests
           dotnet test --configuration Release --no-restore
+
+      # Native AOT regression guard. Publishing (not building) runs the trim/AOT
+      # whole-program analysis, and running the binary proves the engine works
+      # under Native AOT. If reflection-based JSON or native loading is
+      # reintroduced, this step fails either at publish or at runtime.
+      #
+      # Runs on Linux only: the trim/AOT analysis is over managed code and is
+      # platform-independent, so one OS is sufficient. (Per-platform native
+      # loading is already covered by the Test step on all three OSes.)
+      - name: AOT publish smoke test
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+          cd dotnet-engine
+          dotnet publish Yggdrasil.Engine.AotSmokeTest/Yggdrasil.Engine.AotSmokeTest.csproj \
+            --configuration Release -r linux-x64 -o ./aot-out
+          echo "Running AOT-compiled binary"
+          ./aot-out/Yggdrasil.Engine.AotSmokeTest

--- a/dotnet-engine/Yggdrasil.Engine.AotSmokeTest/Program.cs
+++ b/dotnet-engine/Yggdrasil.Engine.AotSmokeTest/Program.cs
@@ -1,0 +1,38 @@
+using Yggdrasil;
+
+// This program is published with Native AOT (see the .csproj) and executed in CI.
+// It exists purely as a regression guard: if anyone reintroduces reflection-based
+// JSON serialization or native-library loading into Yggdrasil.Engine, the AOT
+// publish will emit trim/AOT analysis warnings (treated as errors) and/or this
+// program will crash at runtime. A plain `dotnet build` does not catch either of
+// those, because the trim/AOT whole-program analysis only runs on publish.
+//
+// The happy path below deliberately exercises every AOT-sensitive code path:
+//   - `new YggdrasilEngine()`  -> native library extraction + load (NativeLoader)
+//   - `TakeState(...)`         -> source-generated JSON deserialization (FeatureCollection)
+//   - `GetState()`             -> source-generated JSON serialization (Object)
+//   - `IsEnabled(...)`         -> full FFI + flatbuffer roundtrip
+
+const string state =
+    "{\"version\":1,\"features\":[{\"name\":\"testFeature\",\"enabled\":true,\"strategies\":[{\"name\":\"default\"}]}]}";
+
+using var engine = new YggdrasilEngine();
+
+engine.TakeState(state);
+
+var retrievedState = engine.GetState();
+if (!retrievedState.Contains("testFeature"))
+{
+    Console.Error.WriteLine($"AOT smoke test FAILED: GetState() did not round-trip the feature. Got: {retrievedState}");
+    return 1;
+}
+
+var result = engine.IsEnabled("testFeature", new Context());
+if (!result.Enabled)
+{
+    Console.Error.WriteLine("AOT smoke test FAILED: expected 'testFeature' to be enabled.");
+    return 1;
+}
+
+Console.WriteLine("AOT smoke test PASSED: engine initialised, state round-tripped, and IsEnabled evaluated under Native AOT.");
+return 0;

--- a/dotnet-engine/Yggdrasil.Engine.AotSmokeTest/Yggdrasil.Engine.AotSmokeTest.csproj
+++ b/dotnet-engine/Yggdrasil.Engine.AotSmokeTest/Yggdrasil.Engine.AotSmokeTest.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+
+    <!--
+      Publish this app with Native AOT to guard against AOT/trimming regressions
+      in Yggdrasil.Engine. The trim/AOT analysers run whole-program analysis at
+      publish time and catch reflection-based serialization that a plain build
+      does not. Any warning they emit fails the publish.
+    -->
+    <PublishAot>true</PublishAot>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yggdrasil.Engine\Yggdrasil.Engine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet-engine/Yggdrasil.Engine.Tests/Yggdrasil.Engine.Tests.csproj
+++ b/dotnet-engine/Yggdrasil.Engine.Tests/Yggdrasil.Engine.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
+++ b/dotnet-engine/Yggdrasil.Engine/NativeLoader.cs
@@ -119,6 +119,9 @@ internal static class NativeLibLoader
 
     internal static IntPtr LoadFunctionPointer(IntPtr libHandle, string functionName)
     {
+#if NET8_0_OR_GREATER
+        return NativeLibrary.GetExport(libHandle, functionName);
+#else
         var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
         if (nativeLibraryType != null)
         {
@@ -135,6 +138,7 @@ internal static class NativeLibLoader
             return GetProcAddress(libHandle, functionName);
         else
             return dlsym(libHandle, functionName);
+#endif
     }
 
     private static IntPtr LoadBinary(string libPath)
@@ -153,6 +157,9 @@ internal static class NativeLibLoader
 
     private static IntPtr LoadUnixLibrary(string libPath)
     {
+#if NET8_0_OR_GREATER
+        return NativeLibrary.Load(libPath);
+#else
         // Try NativeLibrary.Load (works on .NET Core 3+)
         var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
         if (nativeLibraryType != null)
@@ -166,10 +173,14 @@ internal static class NativeLibLoader
             }
         }
         return dlopen(libPath, RTLD_NOW);
+#endif
     }
 
     private static IntPtr LoadWindowsLibrary(string libPath)
     {
+#if NET8_0_OR_GREATER
+        return NativeLibrary.Load(libPath);
+#else
         // Try NativeLibrary.Load (works on .NET Core 3+)
         var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary, System.Runtime.InteropServices");
         if (nativeLibraryType != null)
@@ -184,6 +195,7 @@ internal static class NativeLibLoader
         }
 
         return LoadLibrary(libPath);
+#endif
     }
 
     [DllImport("kernel32.dll", SetLastError = true)]

--- a/dotnet-engine/Yggdrasil.Engine/Strategies.cs
+++ b/dotnet-engine/Yggdrasil.Engine/Strategies.cs
@@ -56,7 +56,11 @@ internal class CustomStrategies
     }
     internal void MapFeatures(string json)
     {
+#if NET8_0_OR_GREATER
+        var features = JsonSerializer.Deserialize(json, YggdrasilJsonSerializerContext.Default.FeatureCollection)?.Features;
+#else
         var features = JsonSerializer.Deserialize<FeatureCollection>(json, options)?.Features;
+#endif
         mappedFeatures = features?
             .Select(feature => new MappedFeature(feature, MapCustomStrategies(feature.Strategies)))
             .ToDictionary(feature => feature.Name);
@@ -85,7 +89,11 @@ internal class CustomStrategies
             .ToDictionary(strategy => strategy.ResultName,
                 strategy => strategy.IsEnabled(context));
 
+#if NET8_0_OR_GREATER
+        return JsonSerializer.Serialize(strategies, YggdrasilJsonSerializerContext.Default.DictionaryStringBoolean);
+#else
         return JsonSerializer.Serialize(strategies, options);
+#endif
     }
 
     internal IReadOnlyDictionary<string, bool> GetCustomStrategyResults(string toggleName, Context context)

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <Compile Remove="YggdrasilJsonSerializerContext.cs" />
   </ItemGroup>
 
   <Target Name="YggdrasilPreBuild" BeforeTargets="Build" Condition="'$(Configuration)' == 'Debug'">

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -27,6 +27,10 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <Compile Remove="YggdrasilJsonSerializerContext.cs" />

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilEngine.cs
@@ -108,7 +108,11 @@ public sealed class YggdrasilEngine : IDisposable
 
         var getStatePtr = FFI.GetState(state);
         var stateObject = ReadComplex<object>(getStatePtr);
+#if NET8_0_OR_GREATER
+        return JsonSerializer.Serialize(stateObject, YggdrasilJsonSerializerContext.Default.Object!);
+#else
         return JsonSerializer.Serialize(stateObject, jsonOptions);
+#endif
     }
 
     public Response IsEnabled(string toggleName, Context context)
@@ -244,7 +248,11 @@ public sealed class YggdrasilEngine : IDisposable
 
             if (json is null) return null;
 
+#if NET8_0_OR_GREATER
+            var engineResponse = (EngineResponse<TRead>?)JsonSerializer.Deserialize(json, YggdrasilJsonSerializerContext.Default.GetTypeInfo(typeof(EngineResponse<TRead>))!);
+#else
             var engineResponse = JsonSerializer.Deserialize<EngineResponse<TRead>>(json, jsonOptions);
+#endif
             if (engineResponse is null) return null;
 
             if (engineResponse.StatusCode == "Error")

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilJsonSerializerContext.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilJsonSerializerContext.cs
@@ -1,0 +1,15 @@
+#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Yggdrasil;
+
+[JsonSerializable(typeof(EngineResponse<object>))]
+[JsonSerializable(typeof(System.Text.Json.JsonElement))]
+[JsonSerializable(typeof(FeatureCollection))]
+[JsonSerializable(typeof(Dictionary<string, bool>))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal partial class YggdrasilJsonSerializerContext : JsonSerializerContext
+{
+}
+#endif

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilJsonSerializerContext.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilJsonSerializerContext.cs
@@ -1,5 +1,6 @@
 #if NET8_0_OR_GREATER
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Yggdrasil;
@@ -8,6 +9,7 @@ namespace Yggdrasil;
 [JsonSerializable(typeof(System.Text.Json.JsonElement))]
 [JsonSerializable(typeof(FeatureCollection))]
 [JsonSerializable(typeof(Dictionary<string, bool>))]
+[JsonSerializable(typeof(JsonElement))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class YggdrasilJsonSerializerContext : JsonSerializerContext
 {

--- a/dotnet-engine/Yggdrasil.Engine/YggdrasilJsonSerializerContext.cs
+++ b/dotnet-engine/Yggdrasil.Engine/YggdrasilJsonSerializerContext.cs
@@ -6,10 +6,9 @@ using System.Text.Json.Serialization;
 namespace Yggdrasil;
 
 [JsonSerializable(typeof(EngineResponse<object>))]
-[JsonSerializable(typeof(System.Text.Json.JsonElement))]
+[JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(FeatureCollection))]
 [JsonSerializable(typeof(Dictionary<string, bool>))]
-[JsonSerializable(typeof(JsonElement))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal partial class YggdrasilJsonSerializerContext : JsonSerializerContext
 {

--- a/dotnet-engine/dotnet-engine.sln
+++ b/dotnet-engine/dotnet-engine.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yggdrasil.Engine", "Yggdras
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yggdrasil.Engine.Tests", "Yggdrasil.Engine.Tests\Yggdrasil.Engine.Tests.csproj", "{53D34278-E160-4E54-857B-AF74F665B8BB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yggdrasil.Engine.AotSmokeTest", "Yggdrasil.Engine.AotSmokeTest\Yggdrasil.Engine.AotSmokeTest.csproj", "{EF93CAA1-04B0-4882-90E2-1DB9BBC28466}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{53D34278-E160-4E54-857B-AF74F665B8BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{53D34278-E160-4E54-857B-AF74F665B8BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53D34278-E160-4E54-857B-AF74F665B8BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF93CAA1-04B0-4882-90E2-1DB9BBC28466}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF93CAA1-04B0-4882-90E2-1DB9BBC28466}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF93CAA1-04B0-4882-90E2-1DB9BBC28466}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF93CAA1-04B0-4882-90E2-1DB9BBC28466}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
# Description

Fix AOT compilation blockers in the .NET engine to support NativeAOT publishing in consuming SDKs.

This is a companion to https://github.com/Unleash/unleash-dotnet-sdk/issues/319 and the SDK-side PR at https://github.com/Unleash/unleash-dotnet-sdk/pull/320 (or equivalent).

## Summary of changes

- **Target framework**: `net6.0` → `net8.0` (net6.0 is EOL; netstandard2.0 retained)
- **NativeLoader reflection removal**: The 3 sites using `Type.GetType("...NativeLibrary").GetMethod().Invoke()` are replaced with direct `NativeLibrary.Load`/`GetExport` calls on net8.0+ via conditional compilation. Reflection path retained for netstandard2.0.
- **STJ source generators**: `JsonSerializer` calls in `YggdrasilEngine.cs` and `Strategies.cs` now use a source-generated `JsonSerializerContext` on net8.0+, avoiding reflection-based serialization. Types covered: `EngineResponse<object>`, `JsonElement`, `FeatureCollection`, `Dictionary<string, bool>`.
- **`IsAotCompatible`**: Enabled for net8.0 with zero analyzer warnings.
- **No public API changes** — all changes are internal.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- All 19 tests pass (including client-specification integration tests)
- Both target frameworks build cleanly: `dotnet build -f netstandard2.0` and `dotnet build -f net8.0`
- `IsAotCompatible` analyzer produces zero warnings on net8.0