### PR TITLE
fix: make release script bump artifact version and not yggdrasil version

### DIFF
--- a/.github/workflows/release-new-ffi-version.yaml
+++ b/.github/workflows/release-new-ffi-version.yaml
@@ -2,11 +2,6 @@ name: Release FFI and Upload Binaries
 
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "New semver version (e.g. 0.2.0)"
-        required: true
-        type: string
 
 jobs:
   create-tag-and-release:
@@ -33,7 +28,21 @@ jobs:
       - name: Set full tag name
         id: tag
         run: |
-          FULL_TAG="yggdrasilffi-v${{ inputs.tag }}"
+          VERSION=$(awk '
+            /^\[package\]$/ { in_package = 1; next }
+            /^\[/ && in_package { exit }
+            in_package && $1 == "version" {
+              gsub(/"/, "", $3)
+              print $3
+              exit
+            }
+          ' yggdrasilffi/Cargo.toml)
+          if [[ -z "$VERSION" || "$VERSION" == "null" ]]; then
+            echo "Could not read yggdrasilffi version from yggdrasilffi/Cargo.toml" >&2
+            exit 1
+          fi
+          FULL_TAG="yggdrasilffi-v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "full_tag=$FULL_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Get latest matching tag

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ git clone --depth 5 --branch v5.1.9 https://github.com/Unleash/client-specificat
 - [Ruby](ruby-engine/README.md)
 - [Python](python-engine/README.md)
 
-## Bumping Yggdrasil Core
+## Bumping the Yggdrasil Crate
 
-Use the release helper when updating the bundled Yggdrasil core version across
-the language bindings:
+Use the release helper when updating the dependency on the Yggdrasil crate:
 
 ```
 ./scripts/bump-yggdrasil-core.py 0.21.3 --dry-run
@@ -46,3 +45,12 @@ The script requires the target core version to be greater than the current
 highest core pin. It updates the Rust core pins, the Java/Python/Ruby/.NET
 native core metadata, and patch-bumps the Java, Python, Ruby, and .NET package
 versions.
+
+## Releasing Yggdrasil FFI
+
+The FFI release version is read from the `version` field in
+`yggdrasilffi/Cargo.toml`.
+
+1. Bump the package version in `yggdrasilffi/Cargo.toml`.
+2. Merge the change to `main`.
+3. Run the `Release FFI and Upload Binaries` GitHub Actions workflow.

--- a/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
+++ b/dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <PackageId>Unleash.Yggdrasil</PackageId>
     <Version>1.3.1</Version>
-    <YggdrasilCoreVersion>0.21.3</YggdrasilCoreVersion>
+    <YggdrasilCoreVersion>0.20.7</YggdrasilCoreVersion>
     <Company>Bricks Software AS</Company>
     <Authors>Unleash</Authors>
     <IncludeSymbols>True</IncludeSymbols>

--- a/java-engine/gradle.properties
+++ b/java-engine/gradle.properties
@@ -1,5 +1,5 @@
 group=io.getunleash
-yggdrasilCoreVersion=0.21.3
+yggdrasilCoreVersion=0.20.7
 version=1.0.2
 clientSpecificationVersion=6.1.0
 clientSpecificationUrlTemplate=https://github.com/Unleash/client-specification/archive/refs/tags/v%s.zip

--- a/python-engine/yggdrasil_engine/__init__.py
+++ b/python-engine/yggdrasil_engine/__init__.py
@@ -1,1 +1,1 @@
-__yggdrasil_core_version__ = "0.21.3"
+__yggdrasil_core_version__ = "0.20.7"

--- a/ruby-engine/yggdrasil-engine.gemspec
+++ b/ruby-engine/yggdrasil-engine.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.add_dependency "ffi", "~> 1.17.2"
   s.platform = target_platform.call
-  s.metadata["yggdrasil_core_version"] = '0.21.3'
+  s.metadata["yggdrasil_core_version"] = '0.20.7'
 end

--- a/scripts/bump-yggdrasil-core.py
+++ b/scripts/bump-yggdrasil-core.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bump the Yggdrasil core version and patch wrapper package versions."""
+"""Bump the Yggdrasil dependency, FFI artifact, and wrapper package versions."""
 
 from __future__ import annotations
 
@@ -29,41 +29,52 @@ class VersionField:
     label: str
 
 
-CORE_FIELDS = [
+FFI_VERSION_FIELD = VersionField(
+    Path("yggdrasilffi/Cargo.toml"),
+    r'^(version\s*=\s*")([^"]+)(")$',
+    "Rust FFI package",
+)
+
+
+YGGDRASIL_DEP_FIELDS = [
     VersionField(
         Path("yggdrasilffi/Cargo.toml"),
         r'(unleash-yggdrasil\s*=\s*\{\s*version\s*=\s*")([^"]+)(")',
-        "Rust FFI core",
+        "Rust FFI Yggdrasil dependency",
     ),
     VersionField(
         Path("pure-wasm/Cargo.toml"),
         r'(unleash-yggdrasil\s*=\s*\{\s*version\s*=\s*")([^"]+)(")',
-        "Pure WASM core",
+        "Pure WASM Yggdrasil dependency",
     ),
     VersionField(
         Path("yggdrasilwasm/Cargo.toml"),
         r'(unleash-yggdrasil\s*=\s*\{\s*version\s*=\s*")([^"]+)(")',
-        "WASM core",
+        "WASM Yggdrasil dependency",
     ),
+]
+
+
+BINDING_ARTIFACT_FIELDS = [
     VersionField(
         Path("java-engine/gradle.properties"),
         r"^(yggdrasilCoreVersion=)(.+)()$",
-        "Java core",
+        "Java FFI artifact",
     ),
     VersionField(
         Path("python-engine/yggdrasil_engine/__init__.py"),
         r'^(__yggdrasil_core_version__\s*=\s*")([^"]+)(")$',
-        "Python core",
+        "Python FFI artifact",
     ),
     VersionField(
         Path("ruby-engine/yggdrasil-engine.gemspec"),
         r'^(  s\.metadata\["yggdrasil_core_version"\]\s*=\s*\')([^\']+)(\')$',
-        "Ruby core",
+        "Ruby FFI artifact",
     ),
     VersionField(
         Path("dotnet-engine/Yggdrasil.Engine/Yggdrasil.Engine.csproj"),
         r"^(\s*<YggdrasilCoreVersion>)([^<]+)(</YggdrasilCoreVersion>)$",
-        ".NET core",
+        ".NET FFI artifact",
     ),
 ]
 
@@ -148,24 +159,43 @@ def apply_replacements(replacements: list[Replacement]) -> None:
         full_path.write_text(text, encoding="utf-8")
 
 
-def plan(target_core_version: str) -> list[tuple[str, str, str]]:
-    parse_semver(target_core_version)
+def plan(target_yggdrasil_version: str) -> list[tuple[str, str, str]]:
+    target_yggdrasil = parse_semver(target_yggdrasil_version)
 
-    core_versions = {field.label: extract_version(field) for field in CORE_FIELDS}
-    for label, version in core_versions.items():
+    yggdrasil_versions = {
+        field.label: extract_version(field)
+        for field in YGGDRASIL_DEP_FIELDS
+    }
+    for version in yggdrasil_versions.values():
         parse_semver(version)
 
-    current_core_version = max(core_versions.values(), key=parse_semver)
-    if parse_semver(target_core_version) <= parse_semver(current_core_version):
+    current_yggdrasil_version = max(yggdrasil_versions.values(), key=parse_semver)
+    if target_yggdrasil <= parse_semver(current_yggdrasil_version):
         raise ValueError(
-            f"target core version {target_core_version} must be greater than "
-            f"current highest core version {current_core_version}"
+            f"target Yggdrasil version {target_yggdrasil_version} must be greater than "
+            f"current highest Yggdrasil dependency version {current_yggdrasil_version}"
         )
+
+    current_ffi_version = extract_version(FFI_VERSION_FIELD)
+    new_ffi_version = patch_bump(current_ffi_version)
 
     changes: list[tuple[str, str, str]] = []
     changes.extend(
-        (field.label, core_versions[field.label], target_core_version)
-        for field in CORE_FIELDS
+        (field.label, yggdrasil_versions[field.label], target_yggdrasil_version)
+        for field in YGGDRASIL_DEP_FIELDS
+    )
+    changes.append((FFI_VERSION_FIELD.label, current_ffi_version, new_ffi_version))
+
+    binding_versions = {
+        field.label: extract_version(field)
+        for field in BINDING_ARTIFACT_FIELDS
+    }
+    for version in binding_versions.values():
+        parse_semver(version)
+
+    changes.extend(
+        (field.label, binding_versions[field.label], new_ffi_version)
+        for field in BINDING_ARTIFACT_FIELDS
     )
 
     for field in PACKAGE_FIELDS:
@@ -178,10 +208,15 @@ def plan(target_core_version: str) -> list[tuple[str, str, str]]:
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Update Yggdrasil core pins and patch-bump Java, Python, Ruby, and .NET packages."
+            "Update the upstream Yggdrasil dependency, patch-bump yggdrasilffi, "
+            "point Java, Python, Ruby, and .NET at the new FFI artifact, and "
+            "patch-bump those package versions."
         )
     )
-    parser.add_argument("core_version", help="New unleash-yggdrasil core version, e.g. 0.21.3")
+    parser.add_argument(
+        "yggdrasil_version",
+        help="New unleash-yggdrasil dependency version, e.g. 0.21.3",
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -190,7 +225,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        changes = plan(args.core_version)
+        changes = plan(args.yggdrasil_version)
     except (RuntimeError, ValueError) as error:
         print(f"error: {error}", file=sys.stderr)
         return 1
@@ -201,10 +236,16 @@ def main() -> int:
     if args.dry_run:
         return 0
 
+    new_ffi_version = patch_bump(extract_version(FFI_VERSION_FIELD))
     replacements = [
-        build_replacement(field, args.core_version)
-        for field in CORE_FIELDS
+        build_replacement(field, args.yggdrasil_version)
+        for field in YGGDRASIL_DEP_FIELDS
     ]
+    replacements.append(build_replacement(FFI_VERSION_FIELD, new_ffi_version))
+    replacements.extend(
+        build_replacement(field, new_ffi_version)
+        for field in BINDING_ARTIFACT_FIELDS
+    )
     replacements.extend(
         build_replacement(field, patch_bump(extract_version(field)))
         for field in PACKAGE_FIELDS

--- a/yggdrasilffi/Cargo.toml
+++ b/yggdrasilffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "yggdrasilffi"
-version = "0.1.0"
+version = "0.20.7"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Reworks the build so that the script updates the yggdrasil ffi artifact version (this project) and not the yggrasil library. Also patches CI to just grab the tag from the FFI crate version and release off that