### PR TITLE
chore: drop python37 from tox

### DIFF
--- a/python-engine/tox.ini
+++ b/python-engine/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311,312,313}-{linux,windows,macosx,musllinux}_{x86_64,arm64}
+    py{38,39,310,311,312,313}-{linux,windows,macosx,musllinux}_{x86_64,arm64}
 
 skipsdist = true
 


### PR DESCRIPTION
This is already dropped in the Python SDK and test CI. This hit EOL in 2023, so seems fair to yeet it