### PR TITLE
refactor: let `is_enabled` accept a fallback and have the bindings layer call it on not found

### DIFF
--- a/python-engine/tests/test_engine.py
+++ b/python-engine/tests/test_engine.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict
 import json
-from yggdrasil_engine.engine import UnleashEngine, Variant, FeatureDefinition
+from unittest.mock import Mock
+from yggdrasil_engine.engine import UnleashEngine, Variant, FeatureDefinition, YggdrasilError
 import json
 import os
 
@@ -215,6 +216,187 @@ def test_get_state_and_roundtrip():
     assert 'status_code' not in retrieved_state
     assert 'error_message' not in retrieved_state
 
+def test_is_enabled_counts_toggle():
+    engine = UnleashEngine()
+
+    state = {
+        "version": 1,
+        "features": [
+            {"name": "testFeature", "enabled": True, "strategies": [{"name": "default"}]}
+        ],
+    }
+    engine.take_state(json.dumps(state))
+
+    engine.is_enabled("testFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics is not None
+    assert metrics["toggles"]["testFeature"]["yes"] == 1
+
+def test_is_enabled_ignores_callback_value_if_engine_responded():
+    engine = UnleashEngine()
+
+    state = {
+        "version": 1,
+        "features": [
+            {"name": "testFeature", "enabled": True, "strategies": [{"name": "default"}]}
+        ],
+    }
+    engine.take_state(json.dumps(state))
+
+    result = engine.is_enabled(
+        "testFeature", {}, fallback_function=lambda name, ctx: False
+    )
+
+    assert result == True
+
+def test_is_enabled_returns_callback_value_if_engine_did_not_respond():
+    engine = UnleashEngine()
+
+    result = engine.is_enabled(
+        "nonExistentFeature", {}, fallback_function=lambda name, ctx: True
+    )
+
+    assert result == True
+
+def _toggle_state(name: str, enabled: bool) -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "features": [
+                {"name": name, "enabled": enabled, "strategies": [{"name": "default"}]}
+            ],
+        }
+    )
+
+def test_is_enabled_ignores_callback_value_when_engine_returns_false():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("disabledFeature", False))
+
+    result = engine.is_enabled(
+        "disabledFeature", {}, fallback_function=lambda name, ctx: True
+    )
+
+    assert result == False
+
+def test_is_enabled_fallback_returning_false_is_respected():
+    engine = UnleashEngine()
+
+    result = engine.is_enabled(
+        "nonExistentFeature", {}, fallback_function=lambda name, ctx: False
+    )
+
+    assert result == False
+
+def test_is_enabled_fallback_receives_toggle_name_and_context():
+    engine = UnleashEngine()
+    context = {"userId": "123"}
+    fallback = Mock(return_value=True)
+
+    engine.is_enabled("nonExistentFeature", context, fallback_function=fallback)
+
+    fallback.assert_called_once_with("nonExistentFeature", context)
+
+def test_is_enabled_fallback_not_invoked_when_toggle_found():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+    fallback = Mock(return_value=True)
+
+    engine.is_enabled("testFeature", {}, fallback_function=fallback)
+
+    fallback.assert_not_called()
+
+def test_is_enabled_counts_fallback_resolved_value_not_raw_response():
+    engine = UnleashEngine()
+
+    engine.is_enabled(
+        "nonExistentFeature", {}, fallback_function=lambda name, ctx: True
+    )
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["nonExistentFeature"]["yes"] == 1
+    assert metrics["toggles"]["nonExistentFeature"].get("no", 0) == 0
+
+def test_is_enabled_returns_none_and_counts_no_when_toggle_missing_without_fallback():
+    engine = UnleashEngine()
+
+    result = engine.is_enabled("nonExistentFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert result is None
+    assert metrics["toggles"]["nonExistentFeature"]["no"] == 1
+
+def test_is_enabled_counts_disabled_toggle_as_no():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("disabledFeature", False))
+
+    engine.is_enabled("disabledFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["disabledFeature"]["no"] == 1
+    assert metrics["toggles"]["disabledFeature"].get("yes", 0) == 0
+
+def test_is_enabled_accumulates_counts_across_multiple_calls():
+    engine = UnleashEngine()
+    state = {
+        "version": 1,
+        "features": [
+            {
+                "name": "enabledFeature",
+                "enabled": True,
+                "strategies": [{"name": "default"}],
+            },
+            {
+                "name": "disabledFeature",
+                "enabled": False,
+                "strategies": [{"name": "default"}],
+            },
+        ],
+    }
+    engine.take_state(json.dumps(state))
+
+    engine.is_enabled("enabledFeature", {})
+    engine.is_enabled("enabledFeature", {})
+    engine.is_enabled("disabledFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["enabledFeature"]["yes"] == 2
+    assert metrics["toggles"]["enabledFeature"].get("no", 0) == 0
+    assert metrics["toggles"]["disabledFeature"]["no"] == 1
+    assert metrics["toggles"]["disabledFeature"].get("yes", 0) == 0
+
+def test_is_enabled_does_not_count_when_engine_raises(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    try:
+        engine.is_enabled("testFeature", {})
+        assert False, "expected YggdrasilError to be raised"
+    except YggdrasilError:
+        pass
+
+    metrics = engine.get_metrics()
+
+    assert metrics is None or "testFeature" not in metrics.get("toggles", {})
+
+def test_is_enabled_fallback_function_must_be_passed_as_keyword():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    try:
+        engine.is_enabled("testFeature", {}, lambda name, ctx: True)
+        assert False, "expected TypeError for positional fallback_function"
+    except TypeError:
+        pass
 
 def test_inc_counter_increments_value():
     engine = UnleashEngine()

--- a/python-engine/tests/test_engine.py
+++ b/python-engine/tests/test_engine.py
@@ -1,7 +1,8 @@
 from dataclasses import asdict
 import json
 from unittest.mock import Mock
-from yggdrasil_engine.engine import UnleashEngine, Variant, FeatureDefinition, YggdrasilError
+import pytest
+from yggdrasil_engine.engine import UnleashEngine, Variant, FeatureToggle, FeatureDefinition, YggdrasilError
 import json
 import os
 
@@ -68,7 +69,7 @@ def test_client_spec():
             toggle_name = test["toggleName"]
             expected_result = test["expectedResult"]
 
-            result = unleash_engine.is_enabled(toggle_name, context) or False
+            result = unleash_engine.is_enabled(toggle_name, context).is_enabled or False
 
             assert (
                 result == expected_result
@@ -114,8 +115,8 @@ def test_custom_strategies_work_end_to_end():
         "Feature.A", {"betterThanSlicedBread": True}
     )
 
-    assert enabled_when_better == True
-    assert disabled_when_not_better == False
+    assert enabled_when_better.is_enabled is True
+    assert disabled_when_not_better.is_enabled is False
     assert should_be_sour_dough.name == "sourDough"
 
 
@@ -249,7 +250,8 @@ def test_is_enabled_ignores_callback_value_if_engine_responded():
         "testFeature", {}, fallback_function=lambda name, ctx: False
     )
 
-    assert result == True
+    assert result.is_enabled is True
+    assert result.is_found is True
 
 def test_is_enabled_returns_callback_value_if_engine_did_not_respond():
     engine = UnleashEngine()
@@ -258,7 +260,7 @@ def test_is_enabled_returns_callback_value_if_engine_did_not_respond():
         "nonExistentFeature", {}, fallback_function=lambda name, ctx: True
     )
 
-    assert result == True
+    assert result.is_enabled is True
 
 def _toggle_state(name: str, enabled: bool) -> str:
     return json.dumps(
@@ -278,7 +280,7 @@ def test_is_enabled_ignores_callback_value_when_engine_returns_false():
         "disabledFeature", {}, fallback_function=lambda name, ctx: True
     )
 
-    assert result == False
+    assert result.is_enabled is False
 
 def test_is_enabled_fallback_returning_false_is_respected():
     engine = UnleashEngine()
@@ -287,7 +289,7 @@ def test_is_enabled_fallback_returning_false_is_respected():
         "nonExistentFeature", {}, fallback_function=lambda name, ctx: False
     )
 
-    assert result == False
+    assert result.is_enabled is False
 
 def test_is_enabled_fallback_receives_toggle_name_and_context():
     engine = UnleashEngine()
@@ -319,14 +321,14 @@ def test_is_enabled_counts_fallback_resolved_value_not_raw_response():
     assert metrics["toggles"]["nonExistentFeature"]["yes"] == 1
     assert metrics["toggles"]["nonExistentFeature"].get("no", 0) == 0
 
-def test_is_enabled_returns_none_and_counts_no_when_toggle_missing_without_fallback():
+def test_is_enabled_reports_not_found_when_toggle_missing_without_fallback():
     engine = UnleashEngine()
 
     result = engine.is_enabled("nonExistentFeature", {})
 
     metrics = engine.get_metrics()
 
-    assert result is None
+    assert result == FeatureToggle("nonExistentFeature", is_enabled=False, is_found=False)
     assert metrics["toggles"]["nonExistentFeature"]["no"] == 1
 
 def test_is_enabled_counts_disabled_toggle_as_no():
@@ -339,6 +341,62 @@ def test_is_enabled_counts_disabled_toggle_as_no():
 
     assert metrics["toggles"]["disabledFeature"]["no"] == 1
     assert metrics["toggles"]["disabledFeature"].get("yes", 0) == 0
+
+def test_is_enabled_returns_feature_toggle_for_enabled_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    result = engine.is_enabled("testFeature", {})
+
+    assert result == FeatureToggle("testFeature", is_enabled=True, is_found=True)
+
+def test_is_enabled_returns_found_feature_toggle_when_toggle_is_disabled():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("disabledFeature", False))
+
+    result = engine.is_enabled("disabledFeature", {})
+
+    assert result == FeatureToggle("disabledFeature", is_enabled=False, is_found=True)
+
+def test_is_enabled_reports_not_found_when_fallback_resolves_value():
+    engine = UnleashEngine()
+
+    result = engine.is_enabled(
+        "nonExistentFeature", {}, fallback_function=lambda name, ctx: True
+    )
+
+    assert result.name == "nonExistentFeature"
+    assert result.is_enabled is True
+    assert result.is_found is False
+
+def test_is_enabled_names_the_queried_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    assert engine.is_enabled("testFeature", {}).name == "testFeature"
+
+def test_is_enabled_coerces_fallback_value_to_bool():
+    engine = UnleashEngine()
+
+    result = engine.is_enabled(
+        "nonExistentFeature", {}, fallback_function=lambda name, ctx: "truthy"
+    )
+
+    assert result.is_enabled is True
+
+def test_feature_toggle_cannot_be_used_as_a_bool():
+    with pytest.raises(TypeError):
+        bool(FeatureToggle("testFeature", is_enabled=True, is_found=True))
+
+def test_is_enabled_result_cannot_be_used_as_a_bool():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    result = engine.is_enabled("testFeature", {})
+
+    with pytest.raises(TypeError):
+        if result:
+            pass
 
 def test_is_enabled_accumulates_counts_across_multiple_calls():
     engine = UnleashEngine()
@@ -370,7 +428,7 @@ def test_is_enabled_accumulates_counts_across_multiple_calls():
     assert metrics["toggles"]["disabledFeature"]["no"] == 1
     assert metrics["toggles"]["disabledFeature"].get("yes", 0) == 0
 
-def test_is_enabled_does_not_count_when_engine_raises(monkeypatch):
+def test_is_enabled_returns_disabled_toggle_when_engine_errors(monkeypatch):
     engine = UnleashEngine()
     monkeypatch.setattr(
         engine,
@@ -378,20 +436,74 @@ def test_is_enabled_does_not_count_when_engine_raises(monkeypatch):
         Mock(side_effect=YggdrasilError("boom")),
     )
 
-    try:
-        engine.is_enabled("testFeature", {})
-        assert False, "expected YggdrasilError to be raised"
-    except YggdrasilError:
-        pass
+    result = engine.is_enabled("testFeature", {})
+
+    assert result == FeatureToggle("testFeature", is_enabled=False, is_found=False)
+
+def test_is_enabled_counts_no_when_engine_errors(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    engine.is_enabled("testFeature", {})
 
     metrics = engine.get_metrics()
 
-    assert metrics is None or "testFeature" not in metrics.get("toggles", {})
+    assert metrics["toggles"]["testFeature"]["no"] == 1
+
+def test_is_enabled_does_not_raise_on_unexpected_engine_failure(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=RuntimeError("kaboom")),
+    )
+
+    result = engine.is_enabled("testFeature", {})
+
+    assert result.is_enabled is False
+    assert result.is_found is False
+
+def test_is_enabled_uses_fallback_when_engine_errors(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.is_enabled(
+        "testFeature", {}, fallback_function=lambda name, ctx: True
+    )
+
+    assert result.is_enabled is True
+    assert result.is_found is False
+
+def test_is_enabled_defaults_to_disabled_when_fallback_raises():
+    engine = UnleashEngine()
+
+    def exploding_fallback(name, ctx):
+        raise RuntimeError("bad fallback")
+
+    result = engine.is_enabled(
+        "nonExistentFeature", {}, fallback_function=exploding_fallback
+    )
+
+    metrics = engine.get_metrics()
+
+    assert result.is_enabled is False
+    assert result.is_found is False
+    assert metrics["toggles"]["nonExistentFeature"]["no"] == 1
 
 def test_is_enabled_fallback_function_must_be_passed_as_keyword():
     engine = UnleashEngine()
     engine.take_state(_toggle_state("testFeature", True))
 
+    ## This TypeError comes from binding the arguments, before any of the
+    ## never-raises handling inside is_enabled can run
     try:
         engine.is_enabled("testFeature", {}, lambda name, ctx: True)
         assert False, "expected TypeError for positional fallback_function"

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -1,5 +1,6 @@
 import ctypes
 import json
+import logging
 import os
 import platform
 from contextlib import contextmanager
@@ -25,6 +26,8 @@ def _get_binary_path():
 
 T = TypeVar("T")
 
+_logger = logging.getLogger(__name__)
+
 
 class StatusCode(Enum):
     OK = "Ok"
@@ -34,6 +37,26 @@ class StatusCode(Enum):
 
 class YggdrasilError(Exception):
     pass
+
+
+@dataclass
+class FeatureToggle:
+    """`FeatureToggle` is the result of querying if a feature is enabled.
+
+    `is_enabled` is the evaluated state of the toggle; `is_found` tells you whether
+    the engine knew about the toggle at all.
+    """
+
+    name: str
+    is_enabled: bool = False
+    is_found: bool = False
+
+    def __bool__(self):
+        raise TypeError(
+            f"FeatureToggle for {self.name!r} has no truth value. "
+            "Read .is_enabled to check whether the feature is enabled, "
+            "or .is_found to check whether the engine knew the toggle."
+        )
 
 
 @dataclass
@@ -250,16 +273,25 @@ class UnleashEngine:
         toggle_name: str,
         context: dict,
         *,
-        fallback_function: Optional[Callable[[str, dict], bool]] = None,
-    ) -> Optional[bool]:
-        status_code, value = self._do_is_enabled(toggle_name, context)
+        fallback_function: Optional[Callable[[str, dict], Any]] = None,
+    ) -> FeatureToggle:
+        try:
+            status_code, value = self._do_is_enabled(toggle_name, context)
+        except Exception:
+            _logger.warning(
+                "Failed to evaluate toggle %s, defaulting to disabled",
+                toggle_name,
+                exc_info=True,
+            )
+            status_code, value = StatusCode.ERROR, False
 
-        if status_code == StatusCode.NOT_FOUND and fallback_function is not None:
-            value = fallback_function(toggle_name, context)
+        if status_code != StatusCode.OK and fallback_function is not None:
+            value = self._resolve_fallback(fallback_function, toggle_name, context)
 
-        self.count_toggle(toggle_name, bool(value))
+        enabled = bool(value)
+        self.count_toggle(toggle_name, enabled)
 
-        return value
+        return FeatureToggle(toggle_name, enabled, status_code == StatusCode.OK)
 
     def get_variant(self, toggle_name: str, context: dict) -> Optional[Variant]:
         serialized_context = json.dumps(context or {})
@@ -428,6 +460,22 @@ class UnleashEngine:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
             return response.status_code, response.value
+
+    def _resolve_fallback(
+        self,
+        fallback_function: Callable[[str, dict], Any],
+        toggle_name: str,
+        context: dict,
+    ) -> bool:
+        try:
+            return bool(fallback_function(toggle_name, context))
+        except Exception:
+            _logger.warning(
+                "Fallback for toggle %s failed, defaulting to disabled",
+                toggle_name,
+                exc_info=True,
+            )
+            return False
 
     def _do_count_toggle(self, toggle_name: str, enabled: bool):
         response_ptr = self.lib.count_toggle(

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -41,15 +41,25 @@ class YggdrasilError(Exception):
 
 @dataclass
 class FeatureToggle:
-    """`FeatureToggle` is the result of querying if a feature is enabled.
-
-    `is_enabled` is the evaluated state of the toggle; `is_found` tells you whether
-    the engine knew about the toggle at all.
-    """
+    """`FeatureToggle` is the result of querying if a feature is enabled."""
 
     name: str
+    """The name of the toggle that was queried."""
+
     is_enabled: bool = False
+    """Whether the feature is enabled for the given context.
+
+    Defaults to `False` when the engine did not know the
+    toggle, or when evaluation failed and no fallback resolved a value.
+    """
+
     is_found: bool = False
+    """Whether the engine knew about the toggle at all.
+
+    `False` means the toggle was missing from the engine's state or evaluation
+    errored. That is distinct from a known toggle that evaluated to disabled,
+    which is `is_found=True, is_enabled=False`.
+    """
 
     def __bool__(self):
         raise TypeError(

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -246,6 +246,9 @@ class UnleashEngine:
             return json.dumps(result.value)
 
     def is_enabled(self, toggle_name: str, context: dict) -> Optional[bool]:
+        return self._do_is_enabled(toggle_name, context)
+
+    def _do_is_enabled(self, toggle_name: str, context: dict) -> Optional[bool]:
         serialized_context = json.dumps(context or {})
         custom_strategy_results = json.dumps(
             self.custom_strategy_handler.evaluate_custom_strategies(
@@ -287,6 +290,9 @@ class UnleashEngine:
         self.custom_strategy_handler.register_custom_strategies(custom_strategies)
 
     def count_toggle(self, toggle_name: str, enabled: bool):
+        self._do_count_toggle(toggle_name, enabled)
+
+    def _do_count_toggle(self, toggle_name: str, enabled: bool):
         response_ptr = self.lib.count_toggle(
             self.state, toggle_name.encode("utf-8"), enabled
         )

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -261,25 +261,6 @@ class UnleashEngine:
 
         return value
 
-    def _do_is_enabled(self, toggle_name: str, context: dict):
-        serialized_context = json.dumps(context or {})
-        custom_strategy_results = json.dumps(
-            self.custom_strategy_handler.evaluate_custom_strategies(
-                toggle_name, context
-            )
-        )
-
-        response_ptr = self.lib.check_enabled(
-            self.state,
-            toggle_name.encode("utf-8"),
-            serialized_context.encode("utf-8"),
-            custom_strategy_results.encode("utf-8"),
-        )
-        with self.materialize_pointer(response_ptr, bool) as response:
-            if response.status_code == StatusCode.ERROR:
-                raise YggdrasilError(response.error_message)
-            return response.status_code, response.value
-
     def get_variant(self, toggle_name: str, context: dict) -> Optional[Variant]:
         serialized_context = json.dumps(context or {})
         custom_strategy_results = json.dumps(
@@ -304,12 +285,6 @@ class UnleashEngine:
 
     def count_toggle(self, toggle_name: str, enabled: bool):
         self._do_count_toggle(toggle_name, enabled)
-
-    def _do_count_toggle(self, toggle_name: str, enabled: bool):
-        response_ptr = self.lib.count_toggle(
-            self.state, toggle_name.encode("utf-8"), enabled
-        )
-        self.lib.free_response(response_ptr)
 
     def count_variant(self, toggle_name: str, variant_name: str):
         response_ptr = self.lib.count_variant(
@@ -434,3 +409,28 @@ class UnleashEngine:
         with self.materialize_pointer(response_ptr, type(None)) as response:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
+
+    def _do_is_enabled(self, toggle_name: str, context: dict):
+        serialized_context = json.dumps(context or {})
+        custom_strategy_results = json.dumps(
+            self.custom_strategy_handler.evaluate_custom_strategies(
+                toggle_name, context
+            )
+        )
+
+        response_ptr = self.lib.check_enabled(
+            self.state,
+            toggle_name.encode("utf-8"),
+            serialized_context.encode("utf-8"),
+            custom_strategy_results.encode("utf-8"),
+        )
+        with self.materialize_pointer(response_ptr, bool) as response:
+            if response.status_code == StatusCode.ERROR:
+                raise YggdrasilError(response.error_message)
+            return response.status_code, response.value
+
+    def _do_count_toggle(self, toggle_name: str, enabled: bool):
+        response_ptr = self.lib.count_toggle(
+            self.state, toggle_name.encode("utf-8"), enabled
+        )
+        self.lib.free_response(response_ptr)

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -326,7 +326,11 @@ class UnleashEngine:
         self.custom_strategy_handler.register_custom_strategies(custom_strategies)
 
     def count_toggle(self, toggle_name: str, enabled: bool):
-        self._do_count_toggle(toggle_name, enabled)
+        response_ptr = self.lib.count_toggle(
+            self.state, toggle_name.encode("utf-8"), enabled
+        )
+        self.lib.free_response(response_ptr)
+
 
     def count_variant(self, toggle_name: str, variant_name: str):
         response_ptr = self.lib.count_variant(
@@ -486,9 +490,3 @@ class UnleashEngine:
                 exc_info=True,
             )
             return False
-
-    def _do_count_toggle(self, toggle_name: str, enabled: bool):
-        response_ptr = self.lib.count_toggle(
-            self.state, toggle_name.encode("utf-8"), enabled
-        )
-        self.lib.free_response(response_ptr)

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -245,10 +245,23 @@ class UnleashEngine:
         with self.materialize_pointer(response_ptr, dict) as result:
             return json.dumps(result.value)
 
-    def is_enabled(self, toggle_name: str, context: dict) -> Optional[bool]:
-        return self._do_is_enabled(toggle_name, context)
+    def is_enabled(
+        self,
+        toggle_name: str,
+        context: dict,
+        *,
+        fallback_function: Optional[Callable[[str, dict], bool]] = None,
+    ) -> Optional[bool]:
+        status_code, value = self._do_is_enabled(toggle_name, context)
 
-    def _do_is_enabled(self, toggle_name: str, context: dict) -> Optional[bool]:
+        if status_code == StatusCode.NOT_FOUND and fallback_function is not None:
+            value = fallback_function(toggle_name, context)
+
+        self.count_toggle(toggle_name, bool(value))
+
+        return value
+
+    def _do_is_enabled(self, toggle_name: str, context: dict):
         serialized_context = json.dumps(context or {})
         custom_strategy_results = json.dumps(
             self.custom_strategy_handler.evaluate_custom_strategies(
@@ -265,7 +278,7 @@ class UnleashEngine:
         with self.materialize_pointer(response_ptr, bool) as response:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
-            return response.value
+            return response.status_code, response.value
 
     def get_variant(self, toggle_name: str, context: dict) -> Optional[Variant]:
         serialized_context = json.dumps(context or {})


### PR DESCRIPTION
## Summary

This merge request adds a new positional argument (optional for good old retro-compatibility) for a callback that provides the default value of a toggle. Also, `count_toggle` is invoked inside the `is_enabled` function so the internals don't spill over to the SDK.

The final goal is for `is_enabled` [^ref] to handle internally both with the counting of the toggle query, and the sending of events to the user-provided callbacks (although that might be making the bindings too "fat" for their purpose?

[^ref]: My guess is that `get_variant` suffers the same pains, but haven't gotten there yet.