### PR TITLE
feat(python-engine): hide get_variant internals

### DIFF
--- a/python-engine/.basedpyright/baseline.json
+++ b/python-engine/.basedpyright/baseline.json
@@ -398,8 +398,8 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 14,
-                    "endColumn": 40,
+                    "startColumn": 17,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -652,14 +652,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAny",
                 "range": {
                     "startColumn": 8,
@@ -776,6 +768,22 @@
                 "range": {
                     "startColumn": 65,
                     "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -2170,6 +2178,1110 @@
                     "endColumn": 30,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 5,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownLambdaType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownLambdaType",
+                "range": {
+                    "startColumn": 77,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 5,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 60,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 75,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 75,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 74,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 74,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 75,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 75,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
             }
         ],
         "./yggdrasil_engine/custom_strategy.py": [
@@ -2605,6 +3717,14 @@
                     "startColumn": 28,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportImplicitStringConcatenation",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 71,
+                    "lineCount": 3
                 }
             },
             {
@@ -3160,58 +4280,66 @@
                 }
             },
             {
-                "code": "reportUnknownMemberType",
+                "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 22,
+                    "startColumn": 25,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 33,
+                    "startColumn": 33,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 33,
+                    "startColumn": 12,
+                    "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownArgumentType",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -3772,6 +4900,86 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingTypeArgument",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 61,
                     "lineCount": 1
                 }
             },

--- a/python-engine/.basedpyright/baseline.json
+++ b/python-engine/.basedpyright/baseline.json
@@ -2966,16 +2966,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 75,
-                    "endColumn": 86,
+                    "startColumn": 4,
+                    "endColumn": 15,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 75,
-                    "endColumn": 86,
+                    "startColumn": 4,
+                    "endColumn": 15,
                     "lineCount": 1
                 }
             },
@@ -3046,16 +3046,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 63,
-                    "endColumn": 74,
+                    "startColumn": 69,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 63,
-                    "endColumn": 74,
+                    "startColumn": 69,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -3086,16 +3086,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 75,
+                    "startColumn": 65,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 75,
+                    "startColumn": 65,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -3166,16 +3166,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 74,
-                    "endColumn": 85,
+                    "startColumn": 62,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 74,
-                    "endColumn": 85,
+                    "startColumn": 62,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -3214,16 +3214,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 75,
-                    "endColumn": 86,
+                    "startColumn": 58,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 75,
-                    "endColumn": 86,
+                    "startColumn": 58,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -4282,32 +4282,32 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 56,
+                    "startColumn": 43,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 56,
+                    "startColumn": 43,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 66,
+                    "startColumn": 44,
+                    "endColumn": 56,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportUnknownArgumentType",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 66,
+                    "startColumn": 44,
+                    "endColumn": 56,
                     "lineCount": 1
                 }
             },

--- a/python-engine/.basedpyright/baseline.json
+++ b/python-engine/.basedpyright/baseline.json
@@ -2180,26 +2180,26 @@
                 }
             },
             {
-                "code": "reportUnusedCallResult",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 37,
+                    "startColumn": 15,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 36,
+                    "startColumn": 12,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnusedCallResult",
+                "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 48,
+                    "startColumn": 13,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -2280,30 +2280,6 @@
                 "range": {
                     "startColumn": 13,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnusedCallResult",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 17,
                     "lineCount": 1
                 }
             },
@@ -3717,14 +3693,6 @@
                     "startColumn": 28,
                     "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportImplicitStringConcatenation",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 71,
-                    "lineCount": 3
                 }
             },
             {

--- a/python-engine/.basedpyright/baseline.json
+++ b/python-engine/.basedpyright/baseline.json
@@ -4200,18 +4200,10 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 52,
+                    "startColumn": 20,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
@@ -4220,14 +4212,6 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -4248,66 +4232,10 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 56,
+                    "startColumn": 20,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -4850,14 +4778,6 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
                     "startColumn": 47,
                     "endColumn": 54,
                     "lineCount": 1
@@ -4912,26 +4832,18 @@
                 }
             },
             {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 19,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 23,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -4992,18 +4904,18 @@
                 }
             },
             {
-                "code": "reportUnknownVariableType",
+                "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 19,
-                    "endColumn": 55,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportUnknownMemberType",
+                "code": "reportUnknownVariableType",
                 "range": {
-                    "startColumn": 41,
-                    "endColumn": 55,
+                    "startColumn": 19,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             }

--- a/python-engine/tests/test_engine.py
+++ b/python-engine/tests/test_engine.py
@@ -6,8 +6,10 @@ from unittest.mock import Mock
 import pytest
 
 from yggdrasil_engine.engine import (
+    DISABLED_VARIANT,
     FeatureDefinition,
     FeatureToggle,
+    FeatureVariant,
     UnleashEngine,
     Variant,
     YggdrasilError,
@@ -53,7 +55,11 @@ def test_get_variant_does_not_crash():
         toggle_name = "testToggle"
 
         unleash_engine.take_state(json.dumps(state))
-        print(unleash_engine.get_variant(toggle_name, context))
+        result = unleash_engine.get_variant(toggle_name, context)
+
+        ## simple.json does not carry testToggle, so this exercises the
+        ## substituted disabled variant against a real state file
+        assert result == FeatureVariant(name="testToggle")
 
 
 def test_client_spec():
@@ -86,14 +92,12 @@ def test_client_spec():
             toggle_name = test["toggleName"]
             expected_result = test["expectedResult"]
 
-            result = unleash_engine.get_variant(toggle_name, context) or Variant(
-                "disabled", None, False, False
-            )
+            result = unleash_engine.get_variant(toggle_name, context)
 
             ## We get away with this right now because the casing in the spec tests for feature_enabled
             ## is snake_case. At some point this is going to change to camel case and this is going to break
             expected_json = json.dumps(expected_result)
-            actual_json = json.dumps(variant_to_dict(result))
+            actual_json = json.dumps(variant_to_dict(result.variant))
 
             assert expected_json == actual_json, (
                 f"Failed test '{test['description']}': expected {expected_json}, got {actual_json}"
@@ -123,7 +127,8 @@ def test_custom_strategies_work_end_to_end():
 
     assert enabled_when_better.is_enabled is True
     assert disabled_when_not_better.is_enabled is False
-    assert should_be_sour_dough.name == "sourDough"
+    assert should_be_sour_dough.variant.name == "sourDough"
+    assert should_be_sour_dough.is_found is True
 
 
 def test_increments_counts_for_yes_no_and_variants():
@@ -307,6 +312,44 @@ def _impression_state(name: str, enabled: bool, impression_data: bool) -> str:
                     "name": name,
                     "enabled": enabled,
                     "strategies": [{"name": "default"}],
+                    "impressionData": impression_data,
+                }
+            ],
+        }
+    )
+
+
+def _variant_state(name: str, enabled: bool, variant_name: str, payload=None) -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "features": [
+                {
+                    "name": name,
+                    "enabled": enabled,
+                    "strategies": [{"name": "default"}],
+                    ## A single variant at full weight makes resolution deterministic
+                    "variants": [
+                        {"name": variant_name, "weight": 100, "payload": payload}
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def _variant_impression_state(
+    name: str, enabled: bool, variant_name: str, impression_data: bool
+) -> str:
+    return json.dumps(
+        {
+            "version": 1,
+            "features": [
+                {
+                    "name": name,
+                    "enabled": enabled,
+                    "strategies": [{"name": "default"}],
+                    "variants": [{"name": variant_name, "weight": 100}],
                     "impressionData": impression_data,
                 }
             ],
@@ -988,3 +1031,566 @@ def test_is_enabled_does_not_ask_for_impression_data_when_counting_fails(monkeyp
 
     should_emit.assert_not_called()
     assert result.requires_impression_event_emission is False
+
+
+def test_disabled_variant_is_the_engines_disabled_variant():
+    ## The payload is None rather than {} so that it drops out of serialization
+    assert DISABLED_VARIANT == Variant(
+        name="disabled", payload=None, enabled=False, feature_enabled=False
+    )
+
+
+def test_feature_variant_defaults_to_the_disabled_variant():
+    assert FeatureVariant(name="testFeature").variant == DISABLED_VARIANT
+
+
+def test_feature_variant_defaults_to_not_found():
+    assert FeatureVariant(name="testFeature").is_found is False
+
+
+def test_feature_variant_defaults_to_no_impression_event():
+    assert (
+        FeatureVariant(name="testFeature").requires_impression_event_emission is False
+    )
+
+
+def test_feature_variant_rejects_positional_arguments():
+    with pytest.raises(TypeError):
+        FeatureVariant("testFeature")
+
+
+def test_feature_variant_cannot_be_used_as_a_bool():
+    with pytest.raises(TypeError):
+        bool(FeatureVariant(name="testFeature"))
+
+
+def test_feature_variant_equality_includes_the_resolved_variant():
+    sour_dough = FeatureVariant(
+        name="Feature.A",
+        variant=Variant("sourDough", None, True, True),
+        is_found=True,
+    )
+    rye = FeatureVariant(
+        name="Feature.A",
+        variant=Variant("rye", None, True, True),
+        is_found=True,
+    )
+
+    assert sour_dough != rye
+
+
+def test_feature_variant_equality_includes_impression_event_flag():
+    calls_for_emission = FeatureVariant(
+        name="Feature.A",
+        variant=Variant("sourDough", None, True, True),
+        is_found=True,
+        requires_impression_event_emission=True,
+    )
+    does_not_call_for_emission = FeatureVariant(
+        name="Feature.A",
+        variant=Variant("sourDough", None, True, True),
+        is_found=True,
+        requires_impression_event_emission=False,
+    )
+
+    assert calls_for_emission != does_not_call_for_emission
+
+
+def test_feature_variant_defaults_do_not_share_one_variant_instance():
+    first = FeatureVariant(name="firstFeature")
+    second = FeatureVariant(name="secondFeature")
+
+    first.variant.name = "mutated"
+
+    ## Variant is mutable, so handing every default the same object would let one
+    ## caller poison every later result and the module constant itself
+    assert second.variant.name == "disabled"
+    assert DISABLED_VARIANT.name == "disabled"
+
+
+def test_get_variant_returns_the_resolved_variant_for_an_enabled_toggle():
+    engine = UnleashEngine()
+    engine.take_state(
+        _variant_state(
+            "testFeature", True, "sourDough", {"type": "string", "value": "crusty"}
+        )
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=Variant(
+            name="sourDough",
+            payload={"type": "string", "value": "crusty"},
+            enabled=True,
+            feature_enabled=True,
+        ),
+        is_found=True,
+    )
+
+
+def test_get_variant_names_the_queried_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    assert engine.get_variant("testFeature", {}).name == "testFeature"
+
+
+def test_get_variant_reports_found_for_an_enabled_toggle_without_variants():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.is_found is True
+    assert result.variant == Variant(
+        name="disabled", payload=None, enabled=False, feature_enabled=True
+    )
+
+
+def test_get_variant_reports_found_for_a_known_but_disabled_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("disabledFeature", False, "sourDough"))
+
+    result = engine.get_variant("disabledFeature", {})
+
+    ## A disabled toggle resolves to a variant that looks exactly like the
+    ## substituted one, so is_found must come from the engine's status code
+    assert result.variant == DISABLED_VARIANT
+    assert result.is_found is True
+
+
+def test_get_variant_resolves_the_variant_for_the_given_context():
+    engine = UnleashEngine()
+    state = {
+        "version": 1,
+        "features": [
+            {
+                "name": "testFeature",
+                "enabled": True,
+                "strategies": [{"name": "default"}],
+                "variants": [
+                    {"name": "sourDough", "weight": 100},
+                    {
+                        "name": "rye",
+                        "weight": 0,
+                        "overrides": [{"contextName": "userId", "values": ["123"]}],
+                    },
+                ],
+            }
+        ],
+    }
+    engine.take_state(json.dumps(state))
+
+    result = engine.get_variant("testFeature", {"userId": "123"})
+
+    ## Only the override can select the zero-weight variant, so this can only
+    ## hold if the context reached the engine
+    assert result.variant.name == "rye"
+
+
+def test_get_variant_result_cannot_be_used_as_a_bool():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    result = engine.get_variant("testFeature", {})
+
+    with pytest.raises(TypeError):
+        if result:
+            pass
+
+
+def test_get_variant_does_not_accept_a_fallback_function():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    ## Unlike is_enabled, there is no user supplied fallback; the disabled
+    ## variant is the only substitution
+    with pytest.raises(TypeError):
+        engine.get_variant("testFeature", {}, fallback_function=lambda name, ctx: None)
+
+
+def test_get_variant_returns_the_disabled_variant_for_an_unknown_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    result = engine.get_variant("nonExistentFeature", {})
+
+    assert result == FeatureVariant(name="nonExistentFeature")
+
+
+def test_get_variant_returns_the_disabled_variant_when_the_engine_has_no_state():
+    engine = UnleashEngine()
+
+    result = engine.get_variant("nonExistentFeature", {})
+
+    assert result.variant == DISABLED_VARIANT
+    assert result.is_found is False
+
+
+def test_get_variant_counts_the_resolved_variant():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    engine.get_variant("testFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["testFeature"]["variants"]["sourDough"] == 1
+
+
+def test_get_variant_counts_an_enabled_toggle_as_yes():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    engine.get_variant("testFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["testFeature"]["yes"] == 1
+    assert metrics["toggles"]["testFeature"].get("no", 0) == 0
+
+
+def test_get_variant_counts_a_disabled_toggle_as_no():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("disabledFeature", False, "sourDough"))
+
+    engine.get_variant("disabledFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["disabledFeature"]["no"] == 1
+    assert metrics["toggles"]["disabledFeature"].get("yes", 0) == 0
+
+
+def test_get_variant_counts_an_enabled_toggle_without_variants_as_yes():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    engine.get_variant("testFeature", {})
+
+    metrics = engine.get_metrics()
+
+    ## The variant is disabled but the feature is not, so the toggle count
+    ## follows feature_enabled rather than the variant's own enabled flag
+    assert metrics["toggles"]["testFeature"]["variants"]["disabled"] == 1
+    assert metrics["toggles"]["testFeature"]["yes"] == 1
+
+
+def test_get_variant_counts_the_substituted_disabled_variant_for_an_unknown_toggle():
+    engine = UnleashEngine()
+
+    engine.get_variant("nonExistentFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["nonExistentFeature"]["variants"]["disabled"] == 1
+
+
+def test_get_variant_counts_an_unknown_toggle_as_no():
+    engine = UnleashEngine()
+
+    engine.get_variant("nonExistentFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["nonExistentFeature"]["no"] == 1
+    assert metrics["toggles"]["nonExistentFeature"].get("yes", 0) == 0
+
+
+def test_get_variant_accumulates_counts_across_multiple_calls():
+    engine = UnleashEngine()
+    state = {
+        "version": 1,
+        "features": [
+            {
+                "name": "enabledFeature",
+                "enabled": True,
+                "strategies": [{"name": "default"}],
+                "variants": [{"name": "sourDough", "weight": 100}],
+            },
+            {
+                "name": "disabledFeature",
+                "enabled": False,
+                "strategies": [{"name": "default"}],
+                "variants": [{"name": "rye", "weight": 100}],
+            },
+        ],
+    }
+    engine.take_state(json.dumps(state))
+
+    engine.get_variant("enabledFeature", {})
+    engine.get_variant("enabledFeature", {})
+    engine.get_variant("disabledFeature", {})
+
+    metrics = engine.get_metrics()
+
+    assert metrics["toggles"]["enabledFeature"]["variants"]["sourDough"] == 2
+    assert metrics["toggles"]["enabledFeature"]["yes"] == 2
+    assert metrics["toggles"]["disabledFeature"]["variants"]["disabled"] == 1
+    assert metrics["toggles"]["disabledFeature"]["no"] == 1
+
+
+def test_get_variant_reports_impression_event_when_toggle_has_impression_data():
+    engine = UnleashEngine()
+    engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.requires_impression_event_emission is True
+
+
+def test_get_variant_does_not_report_impression_event_without_impression_data():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.requires_impression_event_emission is False
+
+
+def test_get_variant_reports_impression_event_for_a_disabled_toggle():
+    engine = UnleashEngine()
+    engine.take_state(
+        _variant_impression_state("disabledFeature", False, "sourDough", True)
+    )
+
+    result = engine.get_variant("disabledFeature", {})
+
+    ## Impression events are emitted for disabled evaluations too, so the
+    ## lookup must not be gated on the resolved variant
+    assert result.variant == DISABLED_VARIANT
+    assert result.requires_impression_event_emission is True
+
+
+def test_get_variant_does_not_report_impression_event_for_unknown_toggle():
+    engine = UnleashEngine()
+
+    result = engine.get_variant("nonExistentFeature", {})
+
+    assert result.is_found is False
+    assert result.requires_impression_event_emission is False
+
+
+def test_get_variant_asks_the_engine_for_the_queried_toggle(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
+    should_emit = Mock(return_value=True)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    engine.get_variant("testFeature", {})
+
+    should_emit.assert_called_once_with("testFeature")
+
+
+def test_get_variant_asks_the_engine_even_when_toggle_is_unknown(monkeypatch):
+    engine = UnleashEngine()
+    should_emit = Mock(return_value=False)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    engine.get_variant("nonExistentFeature", {})
+
+    should_emit.assert_called_once_with("nonExistentFeature")
+
+
+def test_get_variant_returns_the_engines_impression_event_answer(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(engine, "should_emit_impression_event", Mock(return_value=True))
+
+    result = engine.get_variant("testFeature", {})
+
+    ## The state carries no impressionData, so a True here can only come from the engine
+    assert result.requires_impression_event_emission is True
+
+
+def test_get_variant_returns_the_engines_impression_event_denial(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
+    monkeypatch.setattr(
+        engine, "should_emit_impression_event", Mock(return_value=False)
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.requires_impression_event_emission is False
+
+
+def test_get_variant_coerces_impression_event_flag_to_bool(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(engine, "should_emit_impression_event", Mock(return_value=None))
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.requires_impression_event_emission is False
+
+
+def test_get_variant_returns_the_disabled_variant_when_engine_errors(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_get_variant",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result == FeatureVariant(name="testFeature")
+
+
+def test_get_variant_does_not_count_when_engine_errors(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_get_variant",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    engine.get_variant("testFeature", {})
+
+    ## Nothing after the raise is attempted, so there is nothing to count
+    assert engine.get_metrics() is None
+
+
+def test_get_variant_does_not_raise_on_unexpected_engine_failure(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_get_variant",
+        Mock(side_effect=RuntimeError("kaboom")),
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.variant == DISABLED_VARIANT
+    assert result.is_found is False
+
+
+def test_get_variant_does_not_ask_for_impression_data_when_evaluation_errors(
+    monkeypatch,
+):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_get_variant",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+    should_emit = Mock(return_value=True)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    result = engine.get_variant("testFeature", {})
+
+    ## Without an evaluation there is nothing to emit an impression event about
+    should_emit.assert_not_called()
+    assert result.requires_impression_event_emission is False
+
+
+def test_get_variant_defaults_impression_event_to_false_when_lookup_errors(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(
+        engine,
+        "should_emit_impression_event",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    ## A failing impression lookup must not disturb the evaluation itself
+    assert result.requires_impression_event_emission is False
+    assert result.variant.name == "sourDough"
+    assert result.is_found is True
+
+
+def test_get_variant_defaults_impression_event_to_false_on_unexpected_lookup_failure(
+    monkeypatch,
+):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(
+        engine,
+        "should_emit_impression_event",
+        Mock(side_effect=RuntimeError("kaboom")),
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.requires_impression_event_emission is False
+    assert result.variant.name == "sourDough"
+    assert result.is_found is True
+
+
+def test_get_variant_still_counts_when_impression_lookup_fails(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(
+        engine,
+        "should_emit_impression_event",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    metrics = engine.get_metrics()
+
+    ## Both counts land before the impression lookup is attempted
+    assert result.requires_impression_event_emission is False
+    assert metrics["toggles"]["testFeature"]["variants"]["sourDough"] == 1
+    assert metrics["toggles"]["testFeature"]["yes"] == 1
+
+
+def test_get_variant_returns_the_evaluation_when_counting_fails(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(
+        engine, "count_variant", Mock(side_effect=YggdrasilError("boom"))
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    ## A metrics failure must not discard an evaluation that already succeeded
+    assert result.variant.name == "sourDough"
+    assert result.is_found is True
+
+
+def test_get_variant_does_not_raise_on_unexpected_counting_failure(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(
+        engine, "count_toggle", Mock(side_effect=RuntimeError("kaboom"))
+    )
+
+    result = engine.get_variant("testFeature", {})
+
+    assert result.variant.name == "sourDough"
+    assert result.is_found is True
+
+
+def test_get_variant_does_not_ask_for_impression_data_when_counting_fails(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
+    monkeypatch.setattr(
+        engine, "count_toggle", Mock(side_effect=YggdrasilError("boom"))
+    )
+    should_emit = Mock(return_value=True)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    result = engine.get_variant("testFeature", {})
+
+    should_emit.assert_not_called()
+    assert result.requires_impression_event_emission is False
+
+
+def test_get_variant_does_not_count_the_toggle_when_variant_counting_fails(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(
+        engine, "count_variant", Mock(side_effect=YggdrasilError("boom"))
+    )
+
+    engine.get_variant("testFeature", {})
+
+    ## The variant is counted first, so its failure leaves the toggle uncounted
+    assert engine.get_metrics() is None

--- a/python-engine/tests/test_engine.py
+++ b/python-engine/tests/test_engine.py
@@ -6,13 +6,13 @@ from unittest.mock import Mock
 import pytest
 
 from yggdrasil_engine.engine import (
-    DISABLED_VARIANT,
     FeatureDefinition,
     FeatureToggle,
     FeatureVariant,
     UnleashEngine,
     Variant,
     YggdrasilError,
+    disabled_variant,
 )
 
 CUSTOM_STRATEGY_STATE = """
@@ -61,7 +61,7 @@ def test_get_variant_does_not_crash():
         ## substituted disabled variant against a real state file
         assert result == FeatureVariant(
             name="testToggle",
-            variant=DISABLED_VARIANT,
+            variant=disabled_variant(),
             is_found=False,
             requires_impression_event_emission=False,
         )
@@ -1040,7 +1040,7 @@ def test_is_enabled_does_not_ask_for_impression_data_when_counting_fails(monkeyp
 
 def test_disabled_variant_is_the_engines_disabled_variant():
     ## The payload is None rather than {} so that it drops out of serialization
-    assert DISABLED_VARIANT == Variant(
+    assert disabled_variant() == Variant(
         name="disabled", payload=None, enabled=False, feature_enabled=False
     )
 
@@ -1048,7 +1048,7 @@ def test_disabled_variant_is_the_engines_disabled_variant():
 def test_feature_variant_cannot_be_mutated():
     result = FeatureVariant(
         name="testFeature",
-        variant=DISABLED_VARIANT,
+        variant=disabled_variant(),
         is_found=False,
         requires_impression_event_emission=False,
     )
@@ -1100,9 +1100,10 @@ def test_get_variant_does_not_share_one_disabled_variant_instance():
     first.variant.name = "mutated"
 
     ## Variant is mutable, so handing every substitution the same object would
-    ## let one caller poison every later result and the module constant itself
+    ## let one caller poison every later result; disabled_variant() builds a
+    ## fresh one per call for exactly that reason
     assert second.variant.name == "disabled"
-    assert DISABLED_VARIANT.name == "disabled"
+    assert disabled_variant().name == "disabled"
 
 
 def test_get_variant_returns_the_resolved_variant_for_an_enabled_toggle():
@@ -1155,7 +1156,7 @@ def test_get_variant_reports_found_for_a_known_but_disabled_toggle():
 
     ## A disabled toggle resolves to a variant that looks exactly like the
     ## substituted one, so is_found must come from the engine's status code
-    assert result.variant == DISABLED_VARIANT
+    assert result.variant == disabled_variant()
     assert result.is_found is True
 
 
@@ -1206,7 +1207,7 @@ def test_get_variant_returns_the_disabled_variant_for_an_unknown_toggle():
 
     assert result == FeatureVariant(
         name="nonExistentFeature",
-        variant=DISABLED_VARIANT,
+        variant=disabled_variant(),
         is_found=False,
         requires_impression_event_emission=False,
     )
@@ -1217,7 +1218,7 @@ def test_get_variant_returns_the_disabled_variant_when_the_engine_has_no_state()
 
     result = engine.get_variant("nonExistentFeature", {})
 
-    assert result.variant == DISABLED_VARIANT
+    assert result.variant == disabled_variant()
     assert result.is_found is False
 
 
@@ -1352,7 +1353,7 @@ def test_get_variant_reports_impression_event_for_a_disabled_toggle():
 
     ## Impression events are emitted for disabled evaluations too, so the
     ## lookup must not be gated on the resolved variant
-    assert result.variant == DISABLED_VARIANT
+    assert result.variant == disabled_variant()
     assert result.requires_impression_event_emission is True
 
 
@@ -1431,7 +1432,7 @@ def test_get_variant_returns_the_disabled_variant_when_engine_errors(monkeypatch
 
     assert result == FeatureVariant(
         name="testFeature",
-        variant=DISABLED_VARIANT,
+        variant=disabled_variant(),
         is_found=False,
         requires_impression_event_emission=False,
     )
@@ -1461,7 +1462,7 @@ def test_get_variant_does_not_raise_on_unexpected_engine_failure(monkeypatch):
 
     result = engine.get_variant("testFeature", {})
 
-    assert result.variant == DISABLED_VARIANT
+    assert result.variant == disabled_variant()
     assert result.is_found is False
 
 
@@ -1484,7 +1485,9 @@ def test_get_variant_does_not_ask_for_impression_data_when_evaluation_errors(
     assert result.requires_impression_event_emission is False
 
 
-def test_get_variant_defaults_impression_event_to_false_when_lookup_errors(monkeypatch):
+def test_get_variant_discards_the_evaluation_when_the_impression_lookup_errors(
+    monkeypatch,
+):
     engine = UnleashEngine()
     engine.take_state(_variant_state("testFeature", True, "sourDough"))
     monkeypatch.setattr(
@@ -1495,13 +1498,17 @@ def test_get_variant_defaults_impression_event_to_false_when_lookup_errors(monke
 
     result = engine.get_variant("testFeature", {})
 
-    ## A failing impression lookup must not disturb the evaluation itself
-    assert result.requires_impression_event_emission is False
-    assert result.variant.name == "sourDough"
-    assert result.is_found is True
+    ## The impression lookup is part of building the result, so its failure
+    ## takes the whole evaluation down to the fallback
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=disabled_variant(),
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
 
 
-def test_get_variant_defaults_impression_event_to_false_on_unexpected_lookup_failure(
+def test_get_variant_discards_the_evaluation_on_unexpected_lookup_failure(
     monkeypatch,
 ):
     engine = UnleashEngine()
@@ -1514,12 +1521,15 @@ def test_get_variant_defaults_impression_event_to_false_on_unexpected_lookup_fai
 
     result = engine.get_variant("testFeature", {})
 
-    assert result.requires_impression_event_emission is False
-    assert result.variant.name == "sourDough"
-    assert result.is_found is True
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=disabled_variant(),
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
 
 
-def test_get_variant_still_counts_when_impression_lookup_fails(monkeypatch):
+def test_get_variant_does_not_count_when_the_impression_lookup_fails(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_variant_state("testFeature", True, "sourDough"))
     monkeypatch.setattr(
@@ -1530,15 +1540,12 @@ def test_get_variant_still_counts_when_impression_lookup_fails(monkeypatch):
 
     result = engine.get_variant("testFeature", {})
 
-    metrics = engine.get_metrics()
-
-    ## Both counts land before the impression lookup is attempted
+    ## The impression lookup runs before either count, so nothing is recorded
     assert result.requires_impression_event_emission is False
-    assert metrics["toggles"]["testFeature"]["variants"]["sourDough"] == 1
-    assert metrics["toggles"]["testFeature"]["yes"] == 1
+    assert engine.get_metrics() is None
 
 
-def test_get_variant_returns_the_evaluation_when_counting_fails(monkeypatch):
+def test_get_variant_discards_the_evaluation_when_counting_fails(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_variant_state("testFeature", True, "sourDough"))
     monkeypatch.setattr(
@@ -1547,9 +1554,13 @@ def test_get_variant_returns_the_evaluation_when_counting_fails(monkeypatch):
 
     result = engine.get_variant("testFeature", {})
 
-    ## A metrics failure must not discard an evaluation that already succeeded
-    assert result.variant.name == "sourDough"
-    assert result.is_found is True
+    ## A metrics failure discards the evaluation that preceded it
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=disabled_variant(),
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
 
 
 def test_get_variant_does_not_raise_on_unexpected_counting_failure(monkeypatch):
@@ -1561,11 +1572,15 @@ def test_get_variant_does_not_raise_on_unexpected_counting_failure(monkeypatch):
 
     result = engine.get_variant("testFeature", {})
 
-    assert result.variant.name == "sourDough"
-    assert result.is_found is True
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=disabled_variant(),
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
 
 
-def test_get_variant_does_not_ask_for_impression_data_when_counting_fails(monkeypatch):
+def test_get_variant_asks_for_impression_data_before_counting(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
     monkeypatch.setattr(
@@ -1576,11 +1591,13 @@ def test_get_variant_does_not_ask_for_impression_data_when_counting_fails(monkey
 
     result = engine.get_variant("testFeature", {})
 
-    should_emit.assert_not_called()
+    ## The lookup lands before counting, but the counting failure still drops
+    ## the result it fed, so the answer never reaches the caller
+    should_emit.assert_called_once_with("testFeature")
     assert result.requires_impression_event_emission is False
 
 
-def test_get_variant_does_not_count_the_toggle_when_variant_counting_fails(monkeypatch):
+def test_get_variant_counts_the_toggle_before_the_variant(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_variant_state("testFeature", True, "sourDough"))
     monkeypatch.setattr(
@@ -1589,5 +1606,7 @@ def test_get_variant_does_not_count_the_toggle_when_variant_counting_fails(monke
 
     engine.get_variant("testFeature", {})
 
-    ## The variant is counted first, so its failure leaves the toggle uncounted
-    assert engine.get_metrics() is None
+    ## The toggle is counted first, so it lands even though the variant did not
+    metrics = engine.get_metrics()
+    assert metrics["toggles"]["testFeature"]["yes"] == 1
+    assert metrics["toggles"]["testFeature"]["variants"] == {}

--- a/python-engine/tests/test_engine.py
+++ b/python-engine/tests/test_engine.py
@@ -1,6 +1,6 @@
 import json
 import os
-from dataclasses import asdict
+from dataclasses import FrozenInstanceError, asdict
 from unittest.mock import Mock
 
 import pytest
@@ -59,7 +59,12 @@ def test_get_variant_does_not_crash():
 
         ## simple.json does not carry testToggle, so this exercises the
         ## substituted disabled variant against a real state file
-        assert result == FeatureVariant(name="testToggle")
+        assert result == FeatureVariant(
+            name="testToggle",
+            variant=DISABLED_VARIANT,
+            is_found=False,
+            requires_impression_event_emission=False,
+        )
 
 
 def test_client_spec():
@@ -1040,28 +1045,16 @@ def test_disabled_variant_is_the_engines_disabled_variant():
     )
 
 
-def test_feature_variant_defaults_to_the_disabled_variant():
-    assert FeatureVariant(name="testFeature").variant == DISABLED_VARIANT
-
-
-def test_feature_variant_defaults_to_not_found():
-    assert FeatureVariant(name="testFeature").is_found is False
-
-
-def test_feature_variant_defaults_to_no_impression_event():
-    assert (
-        FeatureVariant(name="testFeature").requires_impression_event_emission is False
+def test_feature_variant_cannot_be_mutated():
+    result = FeatureVariant(
+        name="testFeature",
+        variant=DISABLED_VARIANT,
+        is_found=False,
+        requires_impression_event_emission=False,
     )
 
-
-def test_feature_variant_rejects_positional_arguments():
-    with pytest.raises(TypeError):
-        FeatureVariant("testFeature")
-
-
-def test_feature_variant_cannot_be_used_as_a_bool():
-    with pytest.raises(TypeError):
-        bool(FeatureVariant(name="testFeature"))
+    with pytest.raises(FrozenInstanceError):
+        result.is_found = True
 
 
 def test_feature_variant_equality_includes_the_resolved_variant():
@@ -1069,11 +1062,13 @@ def test_feature_variant_equality_includes_the_resolved_variant():
         name="Feature.A",
         variant=Variant("sourDough", None, True, True),
         is_found=True,
+        requires_impression_event_emission=False,
     )
     rye = FeatureVariant(
         name="Feature.A",
         variant=Variant("rye", None, True, True),
         is_found=True,
+        requires_impression_event_emission=False,
     )
 
     assert sour_dough != rye
@@ -1096,14 +1091,16 @@ def test_feature_variant_equality_includes_impression_event_flag():
     assert calls_for_emission != does_not_call_for_emission
 
 
-def test_feature_variant_defaults_do_not_share_one_variant_instance():
-    first = FeatureVariant(name="firstFeature")
-    second = FeatureVariant(name="secondFeature")
+def test_get_variant_does_not_share_one_disabled_variant_instance():
+    engine = UnleashEngine()
+
+    first = engine.get_variant("firstFeature", {})
+    second = engine.get_variant("secondFeature", {})
 
     first.variant.name = "mutated"
 
-    ## Variant is mutable, so handing every default the same object would let one
-    ## caller poison every later result and the module constant itself
+    ## Variant is mutable, so handing every substitution the same object would
+    ## let one caller poison every later result and the module constant itself
     assert second.variant.name == "disabled"
     assert DISABLED_VARIANT.name == "disabled"
 
@@ -1127,6 +1124,7 @@ def test_get_variant_returns_the_resolved_variant_for_an_enabled_toggle():
             feature_enabled=True,
         ),
         is_found=True,
+        requires_impression_event_emission=False,
     )
 
 
@@ -1190,17 +1188,6 @@ def test_get_variant_resolves_the_variant_for_the_given_context():
     assert result.variant.name == "rye"
 
 
-def test_get_variant_result_cannot_be_used_as_a_bool():
-    engine = UnleashEngine()
-    engine.take_state(_variant_state("testFeature", True, "sourDough"))
-
-    result = engine.get_variant("testFeature", {})
-
-    with pytest.raises(TypeError):
-        if result:
-            pass
-
-
 def test_get_variant_does_not_accept_a_fallback_function():
     engine = UnleashEngine()
     engine.take_state(_variant_state("testFeature", True, "sourDough"))
@@ -1217,7 +1204,12 @@ def test_get_variant_returns_the_disabled_variant_for_an_unknown_toggle():
 
     result = engine.get_variant("nonExistentFeature", {})
 
-    assert result == FeatureVariant(name="nonExistentFeature")
+    assert result == FeatureVariant(
+        name="nonExistentFeature",
+        variant=DISABLED_VARIANT,
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
 
 
 def test_get_variant_returns_the_disabled_variant_when_the_engine_has_no_state():
@@ -1437,7 +1429,12 @@ def test_get_variant_returns_the_disabled_variant_when_engine_errors(monkeypatch
 
     result = engine.get_variant("testFeature", {})
 
-    assert result == FeatureVariant(name="testFeature")
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=DISABLED_VARIANT,
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
 
 
 def test_get_variant_does_not_count_when_engine_errors(monkeypatch):

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -358,16 +358,17 @@ class UnleashEngine:
     ) -> FeatureToggle:
         result = FeatureToggle(name=toggle_name)
         try:
-            status_code, value = self._do_is_enabled(toggle_name, context)
+            value = self._do_is_enabled(toggle_name, context)
+            is_found = value is not None
 
-            if status_code != StatusCode.OK and fallback_function is not None:
+            if not is_found and fallback_function is not None:
                 value = fallback_function(toggle_name, context)
 
             enabled = bool(value)
             result = FeatureToggle(
                 name=toggle_name,
                 is_enabled=enabled,
-                is_found=status_code == StatusCode.OK,
+                is_found=is_found,
             )
 
             self.count_toggle(toggle_name, enabled)
@@ -385,13 +386,13 @@ class UnleashEngine:
 
     def get_variant(self, toggle_name: str, context: dict) -> FeatureVariant:
         try:
-            status_code, value = self._do_get_variant(toggle_name, context)
+            value = self._do_get_variant(toggle_name, context)
             variant = value if value is not None else disabled_variant()
 
             result = FeatureVariant(
                 name=toggle_name,
                 variant=variant,
-                is_found=status_code == StatusCode.OK,
+                is_found=value is not None,
                 requires_impression_event_emission=bool(
                     self.should_emit_impression_event(toggle_name)
                 ),
@@ -551,7 +552,7 @@ class UnleashEngine:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
 
-    def _do_is_enabled(self, toggle_name: str, context: dict):
+    def _do_is_enabled(self, toggle_name: str, context: dict) -> Optional[bool]:
         serialized_context = json.dumps(context or {})
         custom_strategy_results = json.dumps(
             self.custom_strategy_handler.evaluate_custom_strategies(
@@ -568,9 +569,10 @@ class UnleashEngine:
         with self.materialize_pointer(response_ptr, bool) as response:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
-            return response.status_code, response.value
+            ## `None` is the engine saying it does not know this toggle
+            return response.value
 
-    def _do_get_variant(self, toggle_name: str, context: dict):
+    def _do_get_variant(self, toggle_name: str, context: dict) -> Optional[Variant]:
         serialized_context = json.dumps(context or {})
         custom_strategy_results = json.dumps(
             self.custom_strategy_handler.evaluate_custom_strategies(
@@ -587,4 +589,5 @@ class UnleashEngine:
         with self.materialize_pointer(response_ptr, Variant) as response:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
-            return response.status_code, response.value
+            ## `None` is the engine saying it does not know this toggle
+            return response.value

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -4,7 +4,7 @@ import logging
 import os
 import platform
 from contextlib import contextmanager
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, TypeVar, cast
 
@@ -111,9 +111,10 @@ class Variant:
         )
 
 
-DISABLED_VARIANT = Variant(
-    name="disabled", payload=None, enabled=False, feature_enabled=False
-)
+def disabled_variant() -> Variant:
+    return Variant(name="disabled", payload=None, enabled=False, feature_enabled=False)
+
+
 """The variant the engine falls back to when no variant could be resolved.
 
 `payload` is `None` rather than an empty dict so that it drops out of
@@ -383,42 +384,37 @@ class UnleashEngine:
         return result
 
     def get_variant(self, toggle_name: str, context: dict) -> FeatureVariant:
-        ## `FeatureVariant` is frozen but `Variant` is not, so every fallback
-        ## gets its own copy; sharing one would let a caller poison later
-        ## results and the constant itself
-        result = FeatureVariant(
-            name=toggle_name,
-            variant=replace(DISABLED_VARIANT),
-            is_found=False,
-            requires_impression_event_emission=False,
-        )
         try:
             status_code, value = self._do_get_variant(toggle_name, context)
+            variant = value if value is not None else disabled_variant()
 
-            variant = replace(DISABLED_VARIANT) if value is None else value
             result = FeatureVariant(
                 name=toggle_name,
                 variant=variant,
                 is_found=status_code == StatusCode.OK,
-                requires_impression_event_emission=False,
-            )
-
-            self.count_variant(toggle_name, variant.name)
-            self.count_toggle(toggle_name, variant.feature_enabled)
-            result = replace(
-                result,
                 requires_impression_event_emission=bool(
                     self.should_emit_impression_event(toggle_name)
                 ),
             )
+
+            self.count_toggle(toggle_name, variant.feature_enabled)
+            self.count_variant(toggle_name, variant.name)
+
+            return result
         except Exception:
+            result = FeatureVariant(
+                name=toggle_name,
+                variant=disabled_variant(),
+                is_found=False,
+                requires_impression_event_emission=False,
+            )
             _logger.warning(
-                "Failed to fully evaluate variant for toggle %s, returning %s",
+                "Failed to evaluate variant for toggle %s, returning %s",
                 toggle_name,
                 result,
                 exc_info=True,
             )
-        return result
+            return result
 
     def register_custom_strategies(self, custom_strategies: dict):
         self.custom_strategy_handler.register_custom_strategies(custom_strategies)

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -4,7 +4,7 @@ import logging
 import os
 import platform
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, TypeVar, cast
 
@@ -108,6 +108,73 @@ class Variant:
             payload=data.get("payload"),
             enabled=data.get("enabled", False),
             feature_enabled=data.get("featureEnabled", False),
+        )
+
+
+DISABLED_VARIANT = Variant(
+    name="disabled", payload=None, enabled=False, feature_enabled=False
+)
+"""The variant the engine falls back to when no variant could be resolved.
+
+`payload` is `None` rather than an empty dict so that it drops out of
+serialization, matching what the engine itself hands back."""
+
+
+@dataclass(init=False)
+class FeatureVariant:
+    """`FeatureVariant` is the result of querying which variant a feature resolves to."""
+
+    name: str
+    """The name of the toggle that was queried."""
+
+    variant: Variant
+    """The variant the toggle resolved to for the given context.
+
+    Defaults to the disabled variant when the engine did not know the toggle,
+    or when the evaluation failed. Note that a known toggle can resolve to a
+    variant that looks exactly like it, so read `is_found` to tell the two
+    apart.
+    """
+
+    is_found: bool = False
+    """Whether the engine knew about the toggle at all.
+
+    `False` means the toggle was missing from the engine's state or evaluation
+    errored. That is distinct from a known toggle that resolved to the disabled
+    variant, which is `is_found=True`.
+    """
+
+    requires_impression_event_emission: bool = False
+    """Whether the engine expects its caller to emit an impression event.
+
+    These bindings are not concerned with the publishing itself. However,
+    the engine is the source of whether a toggle has the publication of
+    impression events enabled.
+
+    `False` means that the SDK should not emit impression events. It also means
+    the engine could not be asked, either because the lookup itself failed or
+    because an earlier step of the evaluation did."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        variant: Optional[Variant] = None,
+        is_found: bool = False,
+        requires_impression_event_emission: bool = False,
+    ):
+        self.name = name
+        ## `Variant` is mutable, so every default gets its own copy; sharing one
+        ## would let a caller poison later results and the constant itself
+        self.variant = replace(DISABLED_VARIANT) if variant is None else variant
+        self.is_found = is_found
+        self.requires_impression_event_emission = requires_impression_event_emission
+
+    def __bool__(self):
+        raise TypeError(
+            f"FeatureVariant for {self.name!r} has no truth value. "
+            "Read .variant to get the variant the feature resolved to, "
+            "or .is_found to check whether the engine knew the toggle."
         )
 
 
@@ -337,24 +404,31 @@ class UnleashEngine:
             )
         return result
 
-    def get_variant(self, toggle_name: str, context: dict) -> Optional[Variant]:
-        serialized_context = json.dumps(context or {})
-        custom_strategy_results = json.dumps(
-            self.custom_strategy_handler.evaluate_custom_strategies(
-                toggle_name, context
-            )
-        )
+    def get_variant(self, toggle_name: str, context: dict) -> FeatureVariant:
+        result = FeatureVariant(name=toggle_name)
+        try:
+            status_code, value = self._do_get_variant(toggle_name, context)
 
-        response_ptr = self.lib.check_variant(
-            self.state,
-            toggle_name.encode("utf-8"),
-            serialized_context.encode("utf-8"),
-            custom_strategy_results.encode("utf-8"),
-        )
-        with self.materialize_pointer(response_ptr, Variant) as response:
-            if response.status_code == StatusCode.ERROR:
-                raise YggdrasilError(response.error_message)
-            return response.value
+            variant = replace(DISABLED_VARIANT) if value is None else value
+            result = FeatureVariant(
+                name=toggle_name,
+                variant=variant,
+                is_found=status_code == StatusCode.OK,
+            )
+
+            self.count_variant(toggle_name, variant.name)
+            self.count_toggle(toggle_name, variant.feature_enabled)
+            result.requires_impression_event_emission = bool(
+                self.should_emit_impression_event(toggle_name)
+            )
+        except Exception:
+            _logger.warning(
+                "Failed to fully evaluate variant for toggle %s, returning %s",
+                toggle_name,
+                result,
+                exc_info=True,
+            )
+        return result
 
     def register_custom_strategies(self, custom_strategies: dict):
         self.custom_strategy_handler.register_custom_strategies(custom_strategies)
@@ -506,6 +580,25 @@ class UnleashEngine:
             custom_strategy_results.encode("utf-8"),
         )
         with self.materialize_pointer(response_ptr, bool) as response:
+            if response.status_code == StatusCode.ERROR:
+                raise YggdrasilError(response.error_message)
+            return response.status_code, response.value
+
+    def _do_get_variant(self, toggle_name: str, context: dict):
+        serialized_context = json.dumps(context or {})
+        custom_strategy_results = json.dumps(
+            self.custom_strategy_handler.evaluate_custom_strategies(
+                toggle_name, context
+            )
+        )
+
+        response_ptr = self.lib.check_variant(
+            self.state,
+            toggle_name.encode("utf-8"),
+            serialized_context.encode("utf-8"),
+            custom_strategy_results.encode("utf-8"),
+        )
+        with self.materialize_pointer(response_ptr, Variant) as response:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
             return response.status_code, response.value

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -120,7 +120,7 @@ DISABLED_VARIANT = Variant(
 serialization, matching what the engine itself hands back."""
 
 
-@dataclass(init=False)
+@dataclass(frozen=True)
 class FeatureVariant:
     """`FeatureVariant` is the result of querying which variant a feature resolves to."""
 
@@ -130,13 +130,13 @@ class FeatureVariant:
     variant: Variant
     """The variant the toggle resolved to for the given context.
 
-    Defaults to the disabled variant when the engine did not know the toggle,
-    or when the evaluation failed. Note that a known toggle can resolve to a
-    variant that looks exactly like it, so read `is_found` to tell the two
-    apart.
+    `get_variant` hands back the disabled variant when the engine did not know
+    the toggle, or when the evaluation failed. Note that a known toggle can
+    resolve to a variant that looks exactly like it, so read `is_found` to tell
+    the two apart.
     """
 
-    is_found: bool = False
+    is_found: bool
     """Whether the engine knew about the toggle at all.
 
     `False` means the toggle was missing from the engine's state or evaluation
@@ -144,7 +144,7 @@ class FeatureVariant:
     variant, which is `is_found=True`.
     """
 
-    requires_impression_event_emission: bool = False
+    requires_impression_event_emission: bool
     """Whether the engine expects its caller to emit an impression event.
 
     These bindings are not concerned with the publishing itself. However,
@@ -154,28 +154,6 @@ class FeatureVariant:
     `False` means that the SDK should not emit impression events. It also means
     the engine could not be asked, either because the lookup itself failed or
     because an earlier step of the evaluation did."""
-
-    def __init__(
-        self,
-        *,
-        name: str,
-        variant: Optional[Variant] = None,
-        is_found: bool = False,
-        requires_impression_event_emission: bool = False,
-    ):
-        self.name = name
-        ## `Variant` is mutable, so every default gets its own copy; sharing one
-        ## would let a caller poison later results and the constant itself
-        self.variant = replace(DISABLED_VARIANT) if variant is None else variant
-        self.is_found = is_found
-        self.requires_impression_event_emission = requires_impression_event_emission
-
-    def __bool__(self):
-        raise TypeError(
-            f"FeatureVariant for {self.name!r} has no truth value. "
-            "Read .variant to get the variant the feature resolved to, "
-            "or .is_found to check whether the engine knew the toggle."
-        )
 
 
 @dataclass
@@ -405,7 +383,15 @@ class UnleashEngine:
         return result
 
     def get_variant(self, toggle_name: str, context: dict) -> FeatureVariant:
-        result = FeatureVariant(name=toggle_name)
+        ## `FeatureVariant` is frozen but `Variant` is not, so every fallback
+        ## gets its own copy; sharing one would let a caller poison later
+        ## results and the constant itself
+        result = FeatureVariant(
+            name=toggle_name,
+            variant=replace(DISABLED_VARIANT),
+            is_found=False,
+            requires_impression_event_emission=False,
+        )
         try:
             status_code, value = self._do_get_variant(toggle_name, context)
 
@@ -414,12 +400,16 @@ class UnleashEngine:
                 name=toggle_name,
                 variant=variant,
                 is_found=status_code == StatusCode.OK,
+                requires_impression_event_emission=False,
             )
 
             self.count_variant(toggle_name, variant.name)
             self.count_toggle(toggle_name, variant.feature_enabled)
-            result.requires_impression_event_emission = bool(
-                self.should_emit_impression_event(toggle_name)
+            result = replace(
+                result,
+                requires_impression_event_emission=bool(
+                    self.should_emit_impression_event(toggle_name)
+                ),
             )
         except Exception:
             _logger.warning(


### PR DESCRIPTION
Similarly to `is_enabled`, `get_variant` expected callers (our SDK)
to then count the toggle and the variant, decide whether to use the
default variant and resolve whether an impression event should be emmitted.

These changes refactor get_variant so these internals are dealt with
internally in an atomic fashion.
