### PR TITLE
chore(java): move binaries to versioned artifacts

### DIFF
--- a/java-engine/build.gradle.kts
+++ b/java-engine/build.gradle.kts
@@ -18,11 +18,32 @@ plugins {
 version = project.findProperty("version") as String
 
 val binariesDir = file("binaries")
+val yggdrasilCoreVersion = project.findProperty("yggdrasilCoreVersion") as String
 val sonatypeUsername: String? by project
 val sonatypePassword: String? by project
 val signingKey: String? by project
 val signingPassphrase: String? by project
 val mavenCentralToken: String? by project
+
+fun versionedBinaryName(originalName: String): String = when {
+    originalName.endsWith(".so") -> "libyggdrasilffi-$yggdrasilCoreVersion.so"
+    originalName.endsWith(".dylib") -> "libyggdrasilffi-$yggdrasilCoreVersion.dylib"
+    originalName.endsWith(".dll") -> "yggdrasilffi-$yggdrasilCoreVersion.dll"
+    else -> throw GradleException("Unsupported native binary name: $originalName")
+}
+
+fun nativePlatformDirectory(binaryName: String): String = when {
+    binaryName == "libyggdrasilffi_x86_64.so" -> "linux-x86_64"
+    binaryName == "libyggdrasilffi_arm64.so" -> "linux-arm64"
+    binaryName == "libyggdrasilffi_x86_64-musl.so" -> "linux-x86_64-musl"
+    binaryName == "libyggdrasilffi_arm64-musl.so" -> "linux-arm64-musl"
+    binaryName == "libyggdrasilffi_x86_64.dylib" -> "macos-x86_64"
+    binaryName == "libyggdrasilffi_arm64.dylib" -> "macos-arm64"
+    binaryName == "yggdrasilffi_x86_64.dll" -> "windows-x86_64"
+    binaryName == "yggdrasilffi_arm64.dll" -> "windows-arm64"
+    binaryName == "yggdrasilffi_i686.dll" -> "windows-i686"
+    else -> throw GradleException("Unsupported native binary name: $binaryName")
+}
 
 repositories {
     mavenCentral()
@@ -59,8 +80,20 @@ tasks.jar {
             "Implementation-Version" to project.version
         )
     }
-    from(binariesDir) {
-        into("native")
+    binariesDir.listFiles()?.filter { it.isFile }?.forEach { binary ->
+        from(binary) {
+            into("native/${nativePlatformDirectory(binary.name)}")
+            rename { versionedBinaryName(binary.name) }
+        }
+    }
+}
+
+tasks.processResources {
+    inputs.property("yggdrasilCoreVersion", yggdrasilCoreVersion)
+    filesMatching("io/getunleash/engine/version.properties") {
+        expand(
+            "yggdrasilCoreVersion" to yggdrasilCoreVersion
+        )
     }
 }
 
@@ -89,12 +122,16 @@ val copyTestBinary by tasks.register<Copy>("copyTestBinary") {
     val binaryName = when {
         os.contains("mac") && (platform.contains("arm") || platform.contains("aarch")) -> "libyggdrasilffi_arm64.dylib"
         os.contains("mac") -> "libyggdrasilffi_x86_64.dylib"
-        os.contains("win") -> "yggdrasilffi_x86_64.dll"
+        os.contains("win") && (platform.contains("arm") || platform.contains("aarch")) -> "yggdrasilffi_arm64.dll"
+        os.contains("win") && platform.contains("64") -> "yggdrasilffi_x86_64.dll"
+        os.contains("win") -> "yggdrasilffi_i686.dll"
+        os.contains("linux") && (platform.contains("arm") || platform.contains("aarch")) -> "libyggdrasilffi_arm64.so"
         os.contains("linux") -> "libyggdrasilffi_x86_64.so"
         else -> throw GradleException("Unsupported OS")
     }
     from(sourcePath) {
-        rename { binaryName }
+        into(nativePlatformDirectory(binaryName))
+        rename { versionedBinaryName(binaryName) }
     }
     into(targetPath)
     outputs.upToDateWhen { false }

--- a/java-engine/build.gradle.kts
+++ b/java-engine/build.gradle.kts
@@ -73,7 +73,21 @@ tasks.withType<Javadoc> {
     exclude("io/getunleash/engine/Payload.java")
     exclude("io/getunelash/engine/IStrategy.java")
 }
+
+val verifyNativeBinariesForJar by tasks.registering {
+    group = "verification"
+    description = "Verifies native binaries are available before assembling the JAR"
+
+    doLast {
+        val nativeBinaries = binariesDir.listFiles()?.filter { it.isFile }.orEmpty()
+        if (nativeBinaries.isEmpty()) {
+            throw GradleException("No native binaries found in ${binariesDir.absolutePath}")
+        }
+    }
+}
+
 tasks.jar {
+    dependsOn(verifyNativeBinariesForJar)
     manifest {
         attributes(
             "Implementation-Title" to project.name,

--- a/java-engine/src/main/java/io/getunleash/engine/EngineVersions.java
+++ b/java-engine/src/main/java/io/getunleash/engine/EngineVersions.java
@@ -1,0 +1,36 @@
+package io.getunleash.engine;
+
+import java.io.IOException;
+import java.util.Properties;
+
+final class EngineVersions {
+  private static final String VERSION_RESOURCE = "/io/getunleash/engine/version.properties";
+  private static final Properties PROPERTIES = loadProperties();
+
+  private EngineVersions() {}
+
+  static String getBundledYggdrasilCoreVersion() {
+    return requireProperty("yggdrasilCoreVersion");
+  }
+
+  private static Properties loadProperties() {
+    var properties = new Properties();
+    try (var in = EngineVersions.class.getResourceAsStream(VERSION_RESOURCE)) {
+      if (in == null) {
+        throw new IllegalStateException("Missing " + VERSION_RESOURCE);
+      }
+      properties.load(in);
+      return properties;
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read " + VERSION_RESOURCE, e);
+    }
+  }
+
+  private static String requireProperty(String propertyName) {
+    var value = PROPERTIES.getProperty(propertyName);
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalStateException("Missing " + propertyName + " in " + VERSION_RESOURCE);
+    }
+    return value.trim();
+  }
+}

--- a/java-engine/src/main/java/io/getunleash/engine/LibNames.java
+++ b/java-engine/src/main/java/io/getunleash/engine/LibNames.java
@@ -6,26 +6,30 @@ import java.io.IOException;
 import java.util.Locale;
 
 final class LibNames {
-  static String pickForCurrentOsArch() {
+  static NativeLibrary pickForCurrentOsArch(String version) {
     String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
     String arch = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
     if (os.contains("mac")) {
       return arch.contains("aarch64") || arch.contains("arm64")
-          ? "libyggdrasilffi_arm64.dylib"
-          : "libyggdrasilffi_x86_64.dylib";
+          ? new NativeLibrary("macos-arm64", "libyggdrasilffi-" + version + ".dylib")
+          : new NativeLibrary("macos-x86_64", "libyggdrasilffi-" + version + ".dylib");
     } else if (os.contains("win")) {
-      if (arch.contains("arm64")) return "yggdrasilffi_arm64.dll";
-      if (arch.contains("64")) return "yggdrasilffi_x86_64.dll";
-      return "yggdrasilffi_i686.dll";
+      if (arch.contains("arm64")) {
+        return new NativeLibrary("windows-arm64", "yggdrasilffi-" + version + ".dll");
+      }
+      if (arch.contains("64")) {
+        return new NativeLibrary("windows-x86_64", "yggdrasilffi-" + version + ".dll");
+      }
+      return new NativeLibrary("windows-i686", "yggdrasilffi-" + version + ".dll");
     } else { // linux
       if (isMusl()) {
         return arch.contains("aarch64") || arch.contains("arm64")
-            ? "libyggdrasilffi_arm64-musl.so"
-            : "libyggdrasilffi_x86_64-musl.so";
+            ? new NativeLibrary("linux-arm64-musl", "libyggdrasilffi-" + version + ".so")
+            : new NativeLibrary("linux-x86_64-musl", "libyggdrasilffi-" + version + ".so");
       }
       return arch.contains("aarch64") || arch.contains("arm64")
-          ? "libyggdrasilffi_arm64.so"
-          : "libyggdrasilffi_x86_64.so";
+          ? new NativeLibrary("linux-arm64", "libyggdrasilffi-" + version + ".so")
+          : new NativeLibrary("linux-x86_64", "libyggdrasilffi-" + version + ".so");
     }
   }
 
@@ -48,5 +52,23 @@ final class LibNames {
               + e.getMessage());
     }
     return false;
+  }
+
+  static final class NativeLibrary {
+    private final String platformDirectory;
+    private final String fileName;
+
+    NativeLibrary(String platformDirectory, String fileName) {
+      this.platformDirectory = platformDirectory;
+      this.fileName = fileName;
+    }
+
+    String resourcePath() {
+      return "/native/" + platformDirectory + "/" + fileName;
+    }
+
+    String fileName() {
+      return fileName;
+    }
   }
 }

--- a/java-engine/src/main/java/io/getunleash/engine/NativeBridge.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeBridge.java
@@ -4,7 +4,8 @@ import java.nio.ByteBuffer;
 
 public final class NativeBridge {
   static {
-    NativeLoader.loadFromResources(LibNames.pickForCurrentOsArch());
+    NativeLoader.loadFromResources(
+        LibNames.pickForCurrentOsArch(EngineVersions.getBundledYggdrasilCoreVersion()));
   }
 
   // Engine lifecycle

--- a/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
@@ -4,17 +4,17 @@ import java.io.*;
 
 final class NativeLoader {
 
-  static void loadFromResources(String libName) {
-    try (var in = NativeLoader.class.getResourceAsStream("/native/" + libName)) {
-      if (in == null) throw new IllegalStateException("Missing /native/" + libName);
-      var tmp = java.nio.file.Files.createTempFile("ygg_", "_" + libName);
+  static void loadFromResources(LibNames.NativeLibrary library) {
+    try (var in = NativeLoader.class.getResourceAsStream(library.resourcePath())) {
+      if (in == null) throw new IllegalStateException("Missing " + library.resourcePath());
+      var tmp = java.nio.file.Files.createTempFile("ygg_", "_" + library.fileName());
       tmp.toFile().deleteOnExit();
       try (var out = java.nio.file.Files.newOutputStream(tmp)) {
         in.transferTo(out);
       }
       System.load(tmp.toAbsolutePath().toString());
     } catch (Exception e) {
-      throw new RuntimeException("Failed to load native lib " + libName, e);
+      throw new RuntimeException("Failed to load native lib " + library.fileName(), e);
     }
   }
 }

--- a/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
@@ -14,7 +14,7 @@ final class NativeLoader {
       }
       System.load(tmp.toAbsolutePath().toString());
     } catch (Exception e) {
-      throw new RuntimeException("Failed to load native lib " + library.fileName(), e);
+      throw new RuntimeException("Failed to load native lib " + library.resourcePath(), e);
     }
   }
 }

--- a/java-engine/src/main/resources/io/getunleash/engine/version.properties
+++ b/java-engine/src/main/resources/io/getunleash/engine/version.properties
@@ -1,0 +1,1 @@
+yggdrasilCoreVersion=${yggdrasilCoreVersion}


### PR DESCRIPTION
Swaps out the native library loading to use versioned artifacts instead.

This is the first part of a small redesign around the way binaries are loaded to we can support loading in a way that can be cached correctly and allows us to address #110

Requires a bit of fiddling:

- We now require a method to resolve the version of the bindings at runtime so we can reference the full binary path. Previously we only had that at build time, so we're just baking that into the jar and exposing it for query later
- I don't want to swap out the way binaries are published right now because that touches every other engine, so instead the build remaps the binaries into the names that serve out purposes - this is going to be required to use Java's built in loading from classpath - technically not necessary for this PR but I don't want to do it twice