### PR TITLE
fix(python-engine): add the "floor" CPython version required for abi3 to the wheel manifest

### DIFF
--- a/python-engine/scripts/repair_wheel.py
+++ b/python-engine/scripts/repair_wheel.py
@@ -24,7 +24,9 @@ for whl in wheels:
                     new_wheel_data = []
                     for line in wheel_data:
                         if line.startswith("Tag:"):
-                            new_wheel_data.append(f"Tag: py3-{abi_tag}-{platform_tag}")
+                            new_wheel_data.append(
+                                f"Tag: {python_version}-{abi_tag}-{platform_tag}"
+                            )
                         elif line.startswith("Root-Is-Purelib:"):
                             new_wheel_data.append("Root-Is-Purelib: false")
                         else:

--- a/python-engine/tests/test_repair_wheel.py
+++ b/python-engine/tests/test_repair_wheel.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+REPAIR_WHEEL = Path(__file__).parent.parent / "scripts" / "repair_wheel.py"
+
+
+def test_wheel_metadata_tag_matches_the_filename_tag(tmp_path: Path) -> None:
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "staging").mkdir()
+    source = tmp_path / "dist" / "yggdrasil_engine-1.3.2-py3-none-any.whl"
+    with zipfile.ZipFile(source, "w") as wheel:
+        wheel.writestr("yggdrasil_engine-1.3.2.dist-info/WHEEL", "Tag: py3-none-any\n")
+
+    _ = subprocess.run(
+        [sys.executable, str(REPAIR_WHEEL)], cwd=str(tmp_path), check=True
+    )
+
+    repaired = next((tmp_path / "staging").iterdir())
+    with zipfile.ZipFile(repaired) as wheel:
+        metadata = wheel.read("yggdrasil_engine-1.3.2.dist-info/WHEEL").decode()
+    filename_tag = "-".join(repaired.stem.split("-")[-3:])
+    assert [line for line in metadata.splitlines() if line.startswith("Tag:")] == [
+        f"Tag: {filename_tag}"
+    ]


### PR DESCRIPTION
## Summary

The name of the wheel needs to include the specific python version (the "floor", so to speak) so that `uv` doesn't reinstall it every time.

This pull request appends the expected python version to the `Tag` of the wheel.

## How to reproduce

`cd` into a repository that depends on `yggdrasil-bindings` and run `uv sync -vvv`. You will see the following line:

```txt
(.venv) ➜  unleash-python-sdk git:(main) ✗ uv sync -vv 2>&1 | rg "Platform"
**DEBUG Platform tags mismatch for yggdrasil-engine==1.3.1: The distribution is compatible with `abi3`, but you're using CPython 3.8 (`cp38`)**
```

Contributes to https://github.com/Unleash/unleash-python-sdk/issues/394