### PR TITLE
chore: bump to pre-release

### DIFF
--- a/python-engine/pyproject.toml
+++ b/python-engine/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yggdrasil-engine"
-version = "2.0.0a0"
+version = "2.0.0a1"
 description = "Engine for evaluating Unleash feature flags"
 authors = ["Simon Hornby <liquidwicked64@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
The only way to confirm that the wheel manifest error worked is to actually try and install it from `uv`