### PR TITLE
chore: allow binary loading from user defined path

### DIFF
--- a/java-engine/README.md
+++ b/java-engine/README.md
@@ -17,8 +17,7 @@ The Java engine uses JNI and must load a native Yggdrasil library before the eng
 The loader tries native libraries in this order:
 
 1. A path configured with the `io.getunleash.engine.native.path` system property.
-2. The JVM's standard native library lookup using `System.loadLibrary`.
-3. The bundled native library from the JAR.
+2. The bundled native library from the JAR.
 
 The configured path can point either to the exact native library file or to a directory containing the versioned native library for the current platform:
 
@@ -32,7 +31,7 @@ For example, on Linux with Yggdrasil core version `0.20.7`, the directory above 
 /opt/unleash/native/libyggdrasilffi-0.20.7.so
 ```
 
-The same versioned names are used for standard JVM native library lookup:
+The configured directory must use the versioned native library name for the current platform:
 
 ```text
 Linux:   libyggdrasilffi-0.20.7.so

--- a/java-engine/README.md
+++ b/java-engine/README.md
@@ -10,6 +10,56 @@ The Java Engine embeds the Yggdrasil engine using Flatbuffers to communicate wit
 
 The `UnleashEngine` class provides a pure Java wrapper around the Yggdrasil feature evaluation engine. It allows you to evaluate feature toggles and variants entirely in-memory, without calling back to a remote Unleash server at runtime. This is intended to be used as part of a larger project that's capable of fetching the feature toggle definitions.
 
+### Native Library Loading
+
+The Java engine uses JNI and must load a native Yggdrasil library before the engine can be used. By default, the native library is bundled in the JAR and extracted to a temporary file at runtime.
+
+The loader tries native libraries in this order:
+
+1. A path configured with the `io.getunleash.engine.native.path` system property.
+2. The JVM's standard native library lookup using `System.loadLibrary`.
+3. The bundled native library from the JAR.
+
+The configured path can point either to the exact native library file or to a directory containing the versioned native library for the current platform:
+
+```bash
+java -Dio.getunleash.engine.native.path=/opt/unleash/native -jar app.jar
+```
+
+For example, on Linux with Yggdrasil core version `0.20.7`, the directory above should contain:
+
+```text
+/opt/unleash/native/libyggdrasilffi-0.20.7.so
+```
+
+The same versioned names are used for standard JVM native library lookup:
+
+```text
+Linux:   libyggdrasilffi-0.20.7.so
+macOS:   libyggdrasilffi-0.20.7.dylib
+Windows: yggdrasilffi-0.20.7.dll
+```
+
+The matching native binaries are also included in the published JAR under `native/<platform>/`. You can inspect them with:
+
+```bash
+jar tf yggdrasil-engine-<version>.jar | grep '^native/'
+```
+
+You can extract all bundled native binaries with:
+
+```bash
+jar xf yggdrasil-engine-<version>.jar native
+```
+
+Or extract only the platform you need:
+
+```bash
+jar xf yggdrasil-engine-<version>.jar native/linux-x86_64
+```
+
+Then point `io.getunleash.engine.native.path` at the extracted platform directory.
+
 ### 📥 Loading State
 
 Before evaluating any features, you must initialize the engine with feature toggle definitions. This is done using the `takeState` method. The input to takeState should be the raw JSON response from the Unleash `/api/client/features endpoint`. For example:
@@ -136,4 +186,3 @@ You can then run the local publish
 ```
 
 This will build a JAR and make it available in your local maven repository
-

--- a/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
@@ -7,7 +7,9 @@ final class NativeLoader {
   static final String NATIVE_LIBRARY_PATH_PROPERTY = "io.getunleash.engine.native.path";
 
   static void loadFromResources(LibNames.NativeLibrary library) {
-    loadFromConfiguredPath(library);
+    if (loadFromConfiguredPath(library)) {
+      return;
+    }
 
     try (var in = NativeLoader.class.getResourceAsStream(library.resourcePath())) {
       if (in == null) throw new IllegalStateException("Missing " + library.resourcePath());
@@ -22,15 +24,16 @@ final class NativeLoader {
     }
   }
 
-  private static void loadFromConfiguredPath(LibNames.NativeLibrary library) {
+  private static boolean loadFromConfiguredPath(LibNames.NativeLibrary library) {
     var configuredPath = System.getProperty(NATIVE_LIBRARY_PATH_PROPERTY);
     if (configuredPath == null || configuredPath.trim().isEmpty()) {
-      return;
+      return false;
     }
 
     var libraryPath = configuredLibraryPath(configuredPath.trim(), library).toAbsolutePath();
     try {
       System.load(libraryPath.toString());
+      return true;
     } catch (UnsatisfiedLinkError e) {
       throw new RuntimeException(
           "Failed to load native lib from "

--- a/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
+++ b/java-engine/src/main/java/io/getunleash/engine/NativeLoader.java
@@ -1,10 +1,14 @@
 package io.getunleash.engine;
 
-import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 final class NativeLoader {
+  static final String NATIVE_LIBRARY_PATH_PROPERTY = "io.getunleash.engine.native.path";
 
   static void loadFromResources(LibNames.NativeLibrary library) {
+    loadFromConfiguredPath(library);
+
     try (var in = NativeLoader.class.getResourceAsStream(library.resourcePath())) {
       if (in == null) throw new IllegalStateException("Missing " + library.resourcePath());
       var tmp = java.nio.file.Files.createTempFile("ygg_", "_" + library.fileName());
@@ -16,5 +20,31 @@ final class NativeLoader {
     } catch (Exception e) {
       throw new RuntimeException("Failed to load native lib " + library.resourcePath(), e);
     }
+  }
+
+  private static void loadFromConfiguredPath(LibNames.NativeLibrary library) {
+    var configuredPath = System.getProperty(NATIVE_LIBRARY_PATH_PROPERTY);
+    if (configuredPath == null || configuredPath.trim().isEmpty()) {
+      return;
+    }
+
+    var libraryPath = configuredLibraryPath(configuredPath.trim(), library).toAbsolutePath();
+    try {
+      System.load(libraryPath.toString());
+    } catch (UnsatisfiedLinkError e) {
+      throw new RuntimeException(
+          "Failed to load native lib from "
+              + NATIVE_LIBRARY_PATH_PROPERTY
+              + "="
+              + configuredPath
+              + " resolved to "
+              + libraryPath,
+          e);
+    }
+  }
+
+  static Path configuredLibraryPath(String configuredPath, LibNames.NativeLibrary library) {
+    var path = Path.of(configuredPath);
+    return Files.isDirectory(path) ? path.resolve(library.fileName()) : path;
   }
 }

--- a/java-engine/src/test/java/io/getunleash/engine/NativeLoaderTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/NativeLoaderTest.java
@@ -1,0 +1,28 @@
+package io.getunleash.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class NativeLoaderTest {
+
+  private static final LibNames.NativeLibrary NATIVE_LIBRARY =
+      new LibNames.NativeLibrary(
+          "linux-x86_64", "libyggdrasilffi-0.20.7.so", "yggdrasilffi-0.20.7");
+
+  @Test
+  void configuredLibraryPathUsesDirectFilePath() {
+    var configuredPath = "/opt/unleash/libyggdrasilffi-0.20.7.so";
+
+    assertThat(NativeLoader.configuredLibraryPath(configuredPath, NATIVE_LIBRARY))
+        .isEqualTo(Path.of(configuredPath));
+  }
+
+  @Test
+  void configuredLibraryPathResolvesVersionedFileNameInsideConfiguredDirectory(@TempDir Path dir) {
+    assertThat(NativeLoader.configuredLibraryPath(dir.toString(), NATIVE_LIBRARY))
+        .isEqualTo(dir.resolve("libyggdrasilffi-0.20.7.so"));
+  }
+}

--- a/java-engine/src/test/java/io/getunleash/engine/NativeLoaderTest.java
+++ b/java-engine/src/test/java/io/getunleash/engine/NativeLoaderTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.io.TempDir;
 class NativeLoaderTest {
 
   private static final LibNames.NativeLibrary NATIVE_LIBRARY =
-      new LibNames.NativeLibrary(
-          "linux-x86_64", "libyggdrasilffi-0.20.7.so", "yggdrasilffi-0.20.7");
+      new LibNames.NativeLibrary("linux-x86_64", "libyggdrasilffi-0.20.7.so");
 
   @Test
   void configuredLibraryPathUsesDirectFilePath() {


### PR DESCRIPTION
Allows loading the native binaries for Java from a user defined path. Should close #110 