### PR TITLE
feat: add new check_* methods for no side effects

### DIFF
--- a/python-engine/.basedpyright/baseline.json
+++ b/python-engine/.basedpyright/baseline.json
@@ -3258,6 +3258,710 @@
                     "endColumn": 41,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownLambdaType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 83,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownLambdaType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownLambdaType",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownLambdaType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedParameter",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 5,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
             }
         ],
         "./yggdrasil_engine/custom_strategy.py": [
@@ -4202,16 +4906,56 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 39,
+                    "startColumn": 25,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAny",
+                "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 16,
+                    "startColumn": 8,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingTypeArgument",
+                "range": {
+                    "startColumn": 17,
                     "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingTypeArgument",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -4234,8 +4978,32 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 40,
+                    "startColumn": 32,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingTypeArgument",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -4772,6 +5540,86 @@
                 "range": {
                     "startColumn": 38,
                     "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingTypeArgument",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingTypeArgument",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportExplicitAny",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAny",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingTypeArgument",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },

--- a/python-engine/.basedpyright/baseline.json
+++ b/python-engine/.basedpyright/baseline.json
@@ -1934,16 +1934,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 74,
-                    "endColumn": 85,
+                    "startColumn": 4,
+                    "endColumn": 15,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 74,
-                    "endColumn": 85,
+                    "startColumn": 4,
+                    "endColumn": 15,
                     "lineCount": 1
                 }
             },
@@ -2014,16 +2014,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 73,
-                    "endColumn": 84,
+                    "startColumn": 68,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 73,
-                    "endColumn": 84,
+                    "startColumn": 68,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -2054,16 +2054,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 63,
-                    "endColumn": 74,
+                    "startColumn": 64,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 63,
-                    "endColumn": 74,
+                    "startColumn": 64,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -2134,16 +2134,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 73,
-                    "endColumn": 84,
+                    "startColumn": 61,
+                    "endColumn": 72,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 73,
-                    "endColumn": 84,
+                    "startColumn": 61,
+                    "endColumn": 72,
                     "lineCount": 1
                 }
             },
@@ -3382,16 +3382,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 71,
-                    "endColumn": 82,
+                    "startColumn": 63,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 71,
-                    "endColumn": 82,
+                    "startColumn": 63,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
@@ -3424,6 +3424,142 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -3846,16 +3982,16 @@
             {
                 "code": "reportUnknownParameterType",
                 "range": {
-                    "startColumn": 71,
-                    "endColumn": 82,
+                    "startColumn": 63,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 71,
-                    "endColumn": 82,
+                    "startColumn": 63,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
@@ -3888,6 +4024,142 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 5,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnusedCallResult",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },

--- a/python-engine/tests/test_engine.py
+++ b/python-engine/tests/test_engine.py
@@ -1610,3 +1610,365 @@ def test_get_variant_counts_the_toggle_before_the_variant(monkeypatch):
     metrics = engine.get_metrics()
     assert metrics["toggles"]["testFeature"]["yes"] == 1
     assert metrics["toggles"]["testFeature"]["variants"] == {}
+
+
+def test_check_enabled_returns_feature_toggle_for_enabled_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    result = engine.check_enabled("testFeature", {})
+
+    assert result == FeatureToggle(name="testFeature", is_enabled=True, is_found=True)
+
+
+def test_check_enabled_returns_found_feature_toggle_when_toggle_is_disabled():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("disabledFeature", False))
+
+    result = engine.check_enabled("disabledFeature", {})
+
+    assert result == FeatureToggle(
+        name="disabledFeature", is_enabled=False, is_found=True
+    )
+
+
+def test_check_enabled_reports_not_found_when_toggle_missing_without_fallback():
+    engine = UnleashEngine()
+
+    result = engine.check_enabled("nonExistentFeature", {})
+
+    assert result == FeatureToggle(
+        name="nonExistentFeature", is_enabled=False, is_found=False
+    )
+
+
+def test_check_enabled_resolves_the_toggle_for_the_given_context():
+    engine = UnleashEngine()
+    state = {
+        "version": 1,
+        "features": [
+            {
+                "name": "testFeature",
+                "enabled": True,
+                "strategies": [
+                    {
+                        "name": "userWithId",
+                        "parameters": {"userIds": "123"},
+                    }
+                ],
+            }
+        ],
+    }
+    engine.take_state(json.dumps(state))
+
+    assert engine.check_enabled("testFeature", {"userId": "123"}).is_enabled is True
+    assert engine.check_enabled("testFeature", {"userId": "456"}).is_enabled is False
+
+
+def test_check_enabled_does_not_count_the_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    engine.is_enabled("testFeature", {})
+    engine.check_enabled("testFeature", {})
+    engine.check_enabled("testFeature", {})
+
+    ## The whole point of check_enabled: the query leaves no trace in metrics.
+    ## The is_enabled call is what makes this provable, since an engine that
+    ## counted nothing at all would satisfy an empty bucket just as well
+    metrics = engine.get_metrics()
+    assert metrics["toggles"]["testFeature"]["yes"] == 1
+    assert metrics["toggles"]["testFeature"]["no"] == 0
+
+
+def test_check_enabled_does_not_ask_the_engine_about_impression_events(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_impression_state("testFeature", True, True))
+    should_emit = Mock(return_value=True)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    result = engine.check_enabled("testFeature", {})
+
+    should_emit.assert_not_called()
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_enabled_never_requires_an_impression_event():
+    engine = UnleashEngine()
+    engine.take_state(_impression_state("testFeature", True, True))
+
+    result = engine.check_enabled("testFeature", {})
+
+    ## The toggle carries impression data, but a silent query never asks the
+    ## caller to emit anything
+    assert result.is_enabled is True
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_enabled_returns_callback_value_if_engine_did_not_respond():
+    engine = UnleashEngine()
+
+    result = engine.check_enabled(
+        "nonExistentFeature", {}, fallback_function=lambda name, ctx: True
+    )
+
+    assert result.is_enabled is True
+    assert result.is_found is False
+
+
+def test_check_enabled_fallback_receives_toggle_name_and_context():
+    engine = UnleashEngine()
+    context = {"userId": "123"}
+    fallback = Mock(return_value=True)
+
+    engine.check_enabled("nonExistentFeature", context, fallback_function=fallback)
+
+    fallback.assert_called_once_with("nonExistentFeature", context)
+
+
+def test_check_enabled_fallback_not_invoked_when_toggle_found():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+    fallback = Mock(return_value=True)
+
+    engine.check_enabled("testFeature", {}, fallback_function=fallback)
+
+    fallback.assert_not_called()
+
+
+def test_check_enabled_coerces_fallback_value_to_bool():
+    engine = UnleashEngine()
+
+    result = engine.check_enabled(
+        "nonExistentFeature", {}, fallback_function=lambda name, ctx: "truthy"
+    )
+
+    assert result.is_enabled is True
+
+
+def test_check_enabled_fallback_function_must_be_passed_as_keyword():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    ## This TypeError comes from binding the arguments, before any of the
+    ## never-raises handling inside check_enabled can run
+    with pytest.raises(TypeError):
+        engine.check_enabled("testFeature", {}, lambda name, ctx: True)
+
+
+def test_check_enabled_returns_disabled_toggle_when_engine_errors(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.check_enabled("testFeature", {})
+
+    assert result == FeatureToggle(name="testFeature", is_enabled=False, is_found=False)
+
+
+def test_check_enabled_does_not_raise_on_unexpected_engine_failure(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=RuntimeError("kaboom")),
+    )
+
+    result = engine.check_enabled("testFeature", {})
+
+    assert result.is_enabled is False
+    assert result.is_found is False
+
+
+def test_check_enabled_does_not_use_the_fallback_when_engine_errors(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+    fallback = Mock(return_value=True)
+
+    result = engine.check_enabled("testFeature", {}, fallback_function=fallback)
+
+    fallback.assert_not_called()
+    assert result.is_enabled is False
+    assert result.is_found is False
+
+
+def test_check_enabled_defaults_to_disabled_when_fallback_raises():
+    engine = UnleashEngine()
+
+    def exploding_fallback(name, ctx):
+        raise RuntimeError("bad fallback")
+
+    result = engine.check_enabled(
+        "nonExistentFeature", {}, fallback_function=exploding_fallback
+    )
+
+    assert result.is_enabled is False
+    assert result.is_found is False
+
+
+def test_check_enabled_result_cannot_be_used_as_a_bool():
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+
+    result = engine.check_enabled("testFeature", {})
+
+    with pytest.raises(TypeError):
+        if result:
+            pass
+
+
+def test_check_variant_returns_the_resolved_variant():
+    engine = UnleashEngine()
+    engine.take_state(
+        _variant_state(
+            "testFeature", True, "sourDough", {"type": "string", "value": "crusty"}
+        )
+    )
+
+    result = engine.check_variant("testFeature", {})
+
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=Variant(
+            name="sourDough",
+            payload={"type": "string", "value": "crusty"},
+            enabled=True,
+            feature_enabled=True,
+        ),
+        is_found=True,
+        requires_impression_event_emission=False,
+    )
+
+
+def test_check_variant_reports_found_for_a_known_but_disabled_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("disabledFeature", False, "sourDough"))
+
+    result = engine.check_variant("disabledFeature", {})
+
+    ## A disabled toggle resolves to a variant that looks exactly like the
+    ## substituted one, so is_found must come from the engine's status code
+    assert result.variant == disabled_variant()
+    assert result.is_found is True
+
+
+def test_check_variant_returns_the_disabled_variant_for_an_unknown_toggle():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    result = engine.check_variant("nonExistentFeature", {})
+
+    assert result == FeatureVariant(
+        name="nonExistentFeature",
+        variant=disabled_variant(),
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
+
+
+def test_check_variant_resolves_the_variant_for_the_given_context():
+    engine = UnleashEngine()
+    state = {
+        "version": 1,
+        "features": [
+            {
+                "name": "testFeature",
+                "enabled": True,
+                "strategies": [{"name": "default"}],
+                "variants": [
+                    {"name": "sourDough", "weight": 100},
+                    {
+                        "name": "rye",
+                        "weight": 0,
+                        "overrides": [{"contextName": "userId", "values": ["123"]}],
+                    },
+                ],
+            }
+        ],
+    }
+    engine.take_state(json.dumps(state))
+
+    result = engine.check_variant("testFeature", {"userId": "123"})
+
+    ## Only the override can select the zero-weight variant, so this can only
+    ## hold if the context reached the engine
+    assert result.variant.name == "rye"
+
+
+def test_check_variant_does_not_count_the_toggle_or_the_variant():
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+
+    engine.get_variant("testFeature", {})
+    engine.check_variant("testFeature", {})
+    engine.check_variant("testFeature", {})
+
+    ## The whole point of check_variant: the query leaves no trace in metrics.
+    ## The get_variant call is what makes this provable, since an engine that
+    ## counted nothing at all would satisfy an empty bucket just as well
+    metrics = engine.get_metrics()
+    assert metrics["toggles"]["testFeature"]["yes"] == 1
+    assert metrics["toggles"]["testFeature"]["variants"] == {"sourDough": 1}
+
+
+def test_check_variant_does_not_ask_the_engine_about_impression_events(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
+    should_emit = Mock(return_value=True)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    result = engine.check_variant("testFeature", {})
+
+    should_emit.assert_not_called()
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_variant_never_requires_an_impression_event():
+    engine = UnleashEngine()
+    engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
+
+    result = engine.check_variant("testFeature", {})
+
+    ## The toggle carries impression data, but a silent query never asks the
+    ## caller to emit anything
+    assert result.variant.name == "sourDough"
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_variant_returns_the_disabled_variant_when_engine_errors(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_get_variant",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.check_variant("testFeature", {})
+
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=disabled_variant(),
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
+
+
+def test_check_variant_does_not_raise_on_unexpected_engine_failure(monkeypatch):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_get_variant",
+        Mock(side_effect=RuntimeError("kaboom")),
+    )
+
+    result = engine.check_variant("testFeature", {})
+
+    assert result.variant == disabled_variant()
+    assert result.is_found is False

--- a/python-engine/tests/test_engine.py
+++ b/python-engine/tests/test_engine.py
@@ -944,7 +944,9 @@ def test_is_enabled_does_not_ask_for_impression_data_when_evaluation_errors(
     assert result.requires_impression_event_emission is False
 
 
-def test_is_enabled_defaults_impression_event_to_false_when_lookup_errors(monkeypatch):
+def test_is_enabled_discards_the_evaluation_when_the_impression_lookup_errors(
+    monkeypatch,
+):
     engine = UnleashEngine()
     engine.take_state(_impression_state("testFeature", True, True))
     monkeypatch.setattr(
@@ -955,13 +957,10 @@ def test_is_enabled_defaults_impression_event_to_false_when_lookup_errors(monkey
 
     result = engine.is_enabled("testFeature", {})
 
-    ## A failing impression lookup must not disturb the evaluation itself
-    assert result.requires_impression_event_emission is False
-    assert result.is_enabled is True
-    assert result.is_found is True
+    assert result == FeatureToggle(name="testFeature")
 
 
-def test_is_enabled_defaults_impression_event_to_false_on_unexpected_lookup_failure(
+def test_is_enabled_discards_the_evaluation_on_unexpected_lookup_failure(
     monkeypatch,
 ):
     engine = UnleashEngine()
@@ -974,12 +973,10 @@ def test_is_enabled_defaults_impression_event_to_false_on_unexpected_lookup_fail
 
     result = engine.is_enabled("testFeature", {})
 
-    assert result.requires_impression_event_emission is False
-    assert result.is_enabled is True
-    assert result.is_found is True
+    assert result == FeatureToggle(name="testFeature")
 
 
-def test_is_enabled_still_counts_the_toggle_when_impression_lookup_fails(monkeypatch):
+def test_is_enabled_does_not_count_when_the_impression_lookup_fails(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_impression_state("testFeature", True, True))
     monkeypatch.setattr(
@@ -990,13 +987,11 @@ def test_is_enabled_still_counts_the_toggle_when_impression_lookup_fails(monkeyp
 
     result = engine.is_enabled("testFeature", {})
 
-    metrics = engine.get_metrics()
-
     assert result.requires_impression_event_emission is False
-    assert metrics["toggles"]["testFeature"]["yes"] == 1
+    assert engine.get_metrics() is None
 
 
-def test_is_enabled_returns_the_evaluation_when_counting_fails(monkeypatch):
+def test_is_enabled_discards_the_evaluation_when_counting_fails(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_impression_state("testFeature", True, True))
     monkeypatch.setattr(
@@ -1005,9 +1000,7 @@ def test_is_enabled_returns_the_evaluation_when_counting_fails(monkeypatch):
 
     result = engine.is_enabled("testFeature", {})
 
-    ## A metrics failure must not discard an evaluation that already succeeded
-    assert result.is_enabled is True
-    assert result.is_found is True
+    assert result == FeatureToggle(name="testFeature")
 
 
 def test_is_enabled_does_not_raise_on_unexpected_counting_failure(monkeypatch):
@@ -1019,11 +1012,10 @@ def test_is_enabled_does_not_raise_on_unexpected_counting_failure(monkeypatch):
 
     result = engine.is_enabled("testFeature", {})
 
-    assert result.is_enabled is True
-    assert result.is_found is True
+    assert result == FeatureToggle(name="testFeature")
 
 
-def test_is_enabled_does_not_ask_for_impression_data_when_counting_fails(monkeypatch):
+def test_is_enabled_asks_for_impression_data_before_counting(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_impression_state("testFeature", True, True))
     monkeypatch.setattr(
@@ -1034,7 +1026,7 @@ def test_is_enabled_does_not_ask_for_impression_data_when_counting_fails(monkeyp
 
     result = engine.is_enabled("testFeature", {})
 
-    should_emit.assert_not_called()
+    should_emit.assert_called_once_with("testFeature")
     assert result.requires_impression_event_emission is False
 
 
@@ -1681,7 +1673,7 @@ def test_check_enabled_does_not_count_the_toggle():
     assert metrics["toggles"]["testFeature"]["no"] == 0
 
 
-def test_check_enabled_does_not_ask_the_engine_about_impression_events(monkeypatch):
+def test_check_enabled_asks_the_engine_about_impression_events(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_impression_state("testFeature", True, True))
     should_emit = Mock(return_value=True)
@@ -1689,20 +1681,74 @@ def test_check_enabled_does_not_ask_the_engine_about_impression_events(monkeypat
 
     result = engine.check_enabled("testFeature", {})
 
-    should_emit.assert_not_called()
-    assert result.requires_impression_event_emission is False
+    should_emit.assert_called_once_with("testFeature")
+    assert result.requires_impression_event_emission is True
 
 
-def test_check_enabled_never_requires_an_impression_event():
+def test_check_enabled_reports_impression_event_when_toggle_has_impression_data():
     engine = UnleashEngine()
     engine.take_state(_impression_state("testFeature", True, True))
 
     result = engine.check_enabled("testFeature", {})
 
-    ## The toggle carries impression data, but a silent query never asks the
-    ## caller to emit anything
+    ## Skipping the metrics is not the same as skipping impression events: the
+    ## caller still has to emit one for a toggle that carries impression data
     assert result.is_enabled is True
+    assert result.requires_impression_event_emission is True
+
+
+def test_check_enabled_does_not_report_impression_event_without_impression_data():
+    engine = UnleashEngine()
+    engine.take_state(_impression_state("testFeature", True, False))
+
+    result = engine.check_enabled("testFeature", {})
+
     assert result.requires_impression_event_emission is False
+
+
+def test_check_enabled_coerces_impression_event_flag_to_bool(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_toggle_state("testFeature", True))
+    monkeypatch.setattr(engine, "should_emit_impression_event", Mock(return_value=None))
+
+    result = engine.check_enabled("testFeature", {})
+
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_enabled_does_not_ask_for_impression_data_when_evaluation_errors(
+    monkeypatch,
+):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_is_enabled",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+    should_emit = Mock(return_value=True)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    result = engine.check_enabled("testFeature", {})
+
+    ## Without an evaluation there is nothing to emit an impression event about
+    should_emit.assert_not_called()
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_enabled_discards_the_evaluation_when_the_impression_lookup_errors(
+    monkeypatch,
+):
+    engine = UnleashEngine()
+    engine.take_state(_impression_state("testFeature", True, True))
+    monkeypatch.setattr(
+        engine,
+        "should_emit_impression_event",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.check_enabled("testFeature", {})
+
+    assert result == FeatureToggle(name="testFeature")
 
 
 def test_check_enabled_returns_callback_value_if_engine_did_not_respond():
@@ -1918,7 +1964,7 @@ def test_check_variant_does_not_count_the_toggle_or_the_variant():
     assert metrics["toggles"]["testFeature"]["variants"] == {"sourDough": 1}
 
 
-def test_check_variant_does_not_ask_the_engine_about_impression_events(monkeypatch):
+def test_check_variant_asks_the_engine_about_impression_events(monkeypatch):
     engine = UnleashEngine()
     engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
     should_emit = Mock(return_value=True)
@@ -1926,20 +1972,83 @@ def test_check_variant_does_not_ask_the_engine_about_impression_events(monkeypat
 
     result = engine.check_variant("testFeature", {})
 
-    should_emit.assert_not_called()
-    assert result.requires_impression_event_emission is False
+    should_emit.assert_called_once_with("testFeature")
+    assert result.requires_impression_event_emission is True
 
 
-def test_check_variant_never_requires_an_impression_event():
+def test_check_variant_reports_impression_event_when_toggle_has_impression_data():
     engine = UnleashEngine()
     engine.take_state(_variant_impression_state("testFeature", True, "sourDough", True))
 
     result = engine.check_variant("testFeature", {})
 
-    ## The toggle carries impression data, but a silent query never asks the
-    ## caller to emit anything
+    ## Skipping the metrics is not the same as skipping impression events: the
+    ## caller still has to emit one for a toggle that carries impression data
     assert result.variant.name == "sourDough"
+    assert result.requires_impression_event_emission is True
+
+
+def test_check_variant_does_not_report_impression_event_without_impression_data():
+    engine = UnleashEngine()
+    engine.take_state(
+        _variant_impression_state("testFeature", True, "sourDough", False)
+    )
+
+    result = engine.check_variant("testFeature", {})
+
     assert result.requires_impression_event_emission is False
+
+
+def test_check_variant_coerces_impression_event_flag_to_bool(monkeypatch):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(engine, "should_emit_impression_event", Mock(return_value=None))
+
+    result = engine.check_variant("testFeature", {})
+
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_variant_does_not_ask_for_impression_data_when_evaluation_errors(
+    monkeypatch,
+):
+    engine = UnleashEngine()
+    monkeypatch.setattr(
+        engine,
+        "_do_get_variant",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+    should_emit = Mock(return_value=True)
+    monkeypatch.setattr(engine, "should_emit_impression_event", should_emit)
+
+    result = engine.check_variant("testFeature", {})
+
+    ## Without an evaluation there is nothing to emit an impression event about
+    should_emit.assert_not_called()
+    assert result.requires_impression_event_emission is False
+
+
+def test_check_variant_discards_the_evaluation_when_the_impression_lookup_errors(
+    monkeypatch,
+):
+    engine = UnleashEngine()
+    engine.take_state(_variant_state("testFeature", True, "sourDough"))
+    monkeypatch.setattr(
+        engine,
+        "should_emit_impression_event",
+        Mock(side_effect=YggdrasilError("boom")),
+    )
+
+    result = engine.check_variant("testFeature", {})
+
+    ## The impression lookup is part of building the result, so its failure
+    ## takes the whole evaluation down to the fallback
+    assert result == FeatureVariant(
+        name="testFeature",
+        variant=disabled_variant(),
+        is_found=False,
+        requires_impression_event_emission=False,
+    )
 
 
 def test_check_variant_returns_the_disabled_variant_when_engine_errors(monkeypatch):

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -6,7 +6,19 @@ import platform
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Type, TypeVar, cast
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+)
 
 from yggdrasil_engine.custom_strategy import CustomStrategyHandler
 
@@ -206,6 +218,16 @@ class Response:
         )
 
 
+class _ToggleEvaluation(NamedTuple):
+    """The two booleans that come out of resolving a toggle.
+
+    Named rather than a bare pair so that the two cannot be swapped silently at
+    a call site."""
+
+    is_enabled: bool
+    is_found: bool
+
+
 class UnleashEngine:
     def __init__(self):
         binary_path = _get_binary_path()
@@ -356,22 +378,32 @@ class UnleashEngine:
         *,
         fallback_function: Optional[Callable[[str, dict], Any]] = None,
     ) -> FeatureToggle:
+        """Ask whether a feature is enabled, and record the query.
+
+        This records the evaluation against the engine's metrics, so the toggle
+        shows up in the next `get_metrics()` payload, and it asks the engine
+        whether the caller must emit an impression event. Use `check_enabled`
+        to ask the same question without either of those.
+
+        `fallback_function` is consulted only when the engine does not know the
+        toggle; its answer sets `is_enabled` but leaves `is_found` at `False`.
+
+        Never raises: a failed evaluation comes back as the disabled toggle. A
+        failure to record the metrics does not discard an evaluation that has
+        already succeeded.
+        """
         result = FeatureToggle(name=toggle_name)
         try:
-            value = self._do_is_enabled(toggle_name, context)
-            is_found = value is not None
-
-            if not is_found and fallback_function is not None:
-                value = fallback_function(toggle_name, context)
-
-            enabled = bool(value)
+            evaluation = self._is_enabled_or_fallback(
+                toggle_name, context, fallback_function
+            )
             result = FeatureToggle(
                 name=toggle_name,
-                is_enabled=enabled,
-                is_found=is_found,
+                is_enabled=evaluation.is_enabled,
+                is_found=evaluation.is_found,
             )
 
-            self.count_toggle(toggle_name, enabled)
+            self.count_toggle(toggle_name, evaluation.is_enabled)
             result.requires_impression_event_emission = bool(
                 self.should_emit_impression_event(toggle_name)
             )
@@ -384,15 +416,65 @@ class UnleashEngine:
             )
         return result
 
-    def get_variant(self, toggle_name: str, context: dict) -> FeatureVariant:
+    def check_enabled(
+        self,
+        toggle_name: str,
+        context: dict,
+        *,
+        fallback_function: Optional[Callable[[str, dict], Any]] = None,
+    ) -> FeatureToggle:
+        """Ask whether a feature is enabled, without recording the query.
+
+        The answer matches `is_enabled`, but nothing is counted towards the
+        engine's metrics and the engine is never asked about impression events,
+        so `requires_impression_event_emission` is always `False`. Reach for
+        `is_enabled` when the query is a real feature check that should be
+        reported back to Unleash.
+
+        `fallback_function` is consulted only when the engine does not know the
+        toggle; its answer sets `is_enabled` but leaves `is_found` at `False`.
+
+        Never raises: a failed evaluation comes back as the disabled toggle.
+        """
         try:
-            value = self._do_get_variant(toggle_name, context)
-            variant = value if value is not None else disabled_variant()
+            evaluation = self._is_enabled_or_fallback(
+                toggle_name, context, fallback_function
+            )
+            return FeatureToggle(
+                name=toggle_name,
+                is_enabled=evaluation.is_enabled,
+                is_found=evaluation.is_found,
+            )
+        except Exception:
+            result = FeatureToggle(name=toggle_name)
+            _logger.warning(
+                "Failed to evaluate toggle %s, returning %s",
+                toggle_name,
+                result,
+                exc_info=True,
+            )
+            return result
+
+    def get_variant(self, toggle_name: str, context: dict) -> FeatureVariant:
+        """Ask which variant a feature resolves to, and record the query.
+
+        This records both the toggle and the resolved variant against the
+        engine's metrics, so they show up in the next `get_metrics()` payload,
+        and it asks the engine whether the caller must emit an impression
+        event. Use `check_variant` to ask the same question without either of
+        those.
+
+        Never raises: a failed evaluation comes back as the disabled variant.
+        Recording the metrics is part of the evaluation here, so a failure to
+        count discards the answer that preceded it.
+        """
+        try:
+            variant, is_found = self._query_variant(toggle_name, context)
 
             result = FeatureVariant(
                 name=toggle_name,
                 variant=variant,
-                is_found=value is not None,
+                is_found=is_found,
                 requires_impression_event_emission=bool(
                     self.should_emit_impression_event(toggle_name)
                 ),
@@ -402,6 +484,41 @@ class UnleashEngine:
             self.count_variant(toggle_name, variant.name)
 
             return result
+        except Exception:
+            result = FeatureVariant(
+                name=toggle_name,
+                variant=disabled_variant(),
+                is_found=False,
+                requires_impression_event_emission=False,
+            )
+            _logger.warning(
+                "Failed to evaluate variant for toggle %s, returning %s",
+                toggle_name,
+                result,
+                exc_info=True,
+            )
+            return result
+
+    def check_variant(self, toggle_name: str, context: dict) -> FeatureVariant:
+        """Ask which variant a feature resolves to, without recording the query.
+
+        The answer matches `get_variant`, but neither the toggle nor the
+        variant is counted towards the engine's metrics and the engine is never
+        asked about impression events, so `requires_impression_event_emission`
+        is always `False`. Reach for `get_variant` when the query is a real
+        feature check that should be reported back to Unleash.
+
+        Never raises: a failed evaluation comes back as the disabled variant.
+        """
+        try:
+            variant, is_found = self._query_variant(toggle_name, context)
+
+            return FeatureVariant(
+                name=toggle_name,
+                variant=variant,
+                is_found=is_found,
+                requires_impression_event_emission=False,
+            )
         except Exception:
             result = FeatureVariant(
                 name=toggle_name,
@@ -551,6 +668,23 @@ class UnleashEngine:
         with self.materialize_pointer(response_ptr, type(None)) as response:
             if response.status_code == StatusCode.ERROR:
                 raise YggdrasilError(response.error_message)
+
+    def _is_enabled_or_fallback(
+        self,
+        toggle_name: str,
+        context: dict,
+        fallback_function: Optional[Callable[[str, dict], Any]] = None,
+    ) -> _ToggleEvaluation:
+        value = self._do_is_enabled(toggle_name, context)
+        is_found = value is not None
+        if value is None and fallback_function is not None:
+            value = fallback_function(toggle_name, context)
+
+        return _ToggleEvaluation(is_enabled=bool(value), is_found=is_found)
+
+    def _query_variant(self, toggle_name: str, context: dict) -> Tuple[Variant, bool]:
+        value = self._do_get_variant(toggle_name, context)
+        return (value if value is not None else disabled_variant()), value is not None
 
     def _do_is_enabled(self, toggle_name: str, context: dict) -> Optional[bool]:
         serialized_context = json.dumps(context or {})

--- a/python-engine/yggdrasil_engine/engine.py
+++ b/python-engine/yggdrasil_engine/engine.py
@@ -381,18 +381,17 @@ class UnleashEngine:
         """Ask whether a feature is enabled, and record the query.
 
         This records the evaluation against the engine's metrics, so the toggle
-        shows up in the next `get_metrics()` payload, and it asks the engine
-        whether the caller must emit an impression event. Use `check_enabled`
-        to ask the same question without either of those.
+        shows up in the next `get_metrics()` payload. Use `check_enabled` to
+        ask the same question without recording it; both report impression
+        events the same way.
 
         `fallback_function` is consulted only when the engine does not know the
         toggle; its answer sets `is_enabled` but leaves `is_found` at `False`.
 
-        Never raises: a failed evaluation comes back as the disabled toggle. A
-        failure to record the metrics does not discard an evaluation that has
-        already succeeded.
+        Never raises, and answers all or nothing: whatever fails, whether the
+        evaluation, the impression lookup or the recording, the caller gets the
+        disabled toggle rather than a half built answer.
         """
-        result = FeatureToggle(name=toggle_name)
         try:
             evaluation = self._is_enabled_or_fallback(
                 toggle_name, context, fallback_function
@@ -401,20 +400,23 @@ class UnleashEngine:
                 name=toggle_name,
                 is_enabled=evaluation.is_enabled,
                 is_found=evaluation.is_found,
+                requires_impression_event_emission=bool(
+                    self.should_emit_impression_event(toggle_name)
+                ),
             )
 
             self.count_toggle(toggle_name, evaluation.is_enabled)
-            result.requires_impression_event_emission = bool(
-                self.should_emit_impression_event(toggle_name)
-            )
+
+            return result
         except Exception:
+            result = FeatureToggle(name=toggle_name)
             _logger.warning(
-                "Failed to fully evaluate toggle %s, returning %s",
+                "Failed to evaluate toggle %s, returning %s",
                 toggle_name,
                 result,
                 exc_info=True,
             )
-        return result
+            return result
 
     def check_enabled(
         self,
@@ -426,15 +428,21 @@ class UnleashEngine:
         """Ask whether a feature is enabled, without recording the query.
 
         The answer matches `is_enabled`, but nothing is counted towards the
-        engine's metrics and the engine is never asked about impression events,
-        so `requires_impression_event_emission` is always `False`. Reach for
-        `is_enabled` when the query is a real feature check that should be
-        reported back to Unleash.
+        engine's metrics, so the toggle does not show up in the next
+        `get_metrics()` payload. Reach for `is_enabled` when the query is a
+        real feature check that should be reported back to Unleash.
+
+        Impression events are not part of that difference: the engine is still
+        asked whether the caller must emit one, and
+        `requires_impression_event_emission` carries the same answer it would
+        under `is_enabled`.
 
         `fallback_function` is consulted only when the engine does not know the
         toggle; its answer sets `is_enabled` but leaves `is_found` at `False`.
 
-        Never raises: a failed evaluation comes back as the disabled toggle.
+        Never raises, and answers all or nothing: whatever fails, whether the
+        evaluation or the impression lookup, the caller gets the disabled
+        toggle rather than a half built answer.
         """
         try:
             evaluation = self._is_enabled_or_fallback(
@@ -444,6 +452,9 @@ class UnleashEngine:
                 name=toggle_name,
                 is_enabled=evaluation.is_enabled,
                 is_found=evaluation.is_found,
+                requires_impression_event_emission=bool(
+                    self.should_emit_impression_event(toggle_name)
+                ),
             )
         except Exception:
             result = FeatureToggle(name=toggle_name)
@@ -459,14 +470,13 @@ class UnleashEngine:
         """Ask which variant a feature resolves to, and record the query.
 
         This records both the toggle and the resolved variant against the
-        engine's metrics, so they show up in the next `get_metrics()` payload,
-        and it asks the engine whether the caller must emit an impression
-        event. Use `check_variant` to ask the same question without either of
-        those.
+        engine's metrics, so they show up in the next `get_metrics()` payload.
+        Use `check_variant` to ask the same question without recording it; both
+        report impression events the same way.
 
-        Never raises: a failed evaluation comes back as the disabled variant.
-        Recording the metrics is part of the evaluation here, so a failure to
-        count discards the answer that preceded it.
+        Never raises, and answers all or nothing: whatever fails, whether the
+        evaluation, the impression lookup or the recording, the caller gets the
+        disabled variant rather than a half built answer.
         """
         try:
             variant, is_found = self._query_variant(toggle_name, context)
@@ -503,12 +513,18 @@ class UnleashEngine:
         """Ask which variant a feature resolves to, without recording the query.
 
         The answer matches `get_variant`, but neither the toggle nor the
-        variant is counted towards the engine's metrics and the engine is never
-        asked about impression events, so `requires_impression_event_emission`
-        is always `False`. Reach for `get_variant` when the query is a real
-        feature check that should be reported back to Unleash.
+        variant is counted towards the engine's metrics, so neither shows up in
+        the next `get_metrics()` payload. Reach for `get_variant` when the
+        query is a real feature check that should be reported back to Unleash.
 
-        Never raises: a failed evaluation comes back as the disabled variant.
+        Impression events are not part of that difference: the engine is still
+        asked whether the caller must emit one, and
+        `requires_impression_event_emission` carries the same answer it would
+        under `get_variant`.
+
+        Never raises, and answers all or nothing: whatever fails, whether the
+        evaluation or the impression lookup, the caller gets the disabled
+        variant rather than a half built answer.
         """
         try:
             variant, is_found = self._query_variant(toggle_name, context)
@@ -517,7 +533,9 @@ class UnleashEngine:
                 name=toggle_name,
                 variant=variant,
                 is_found=is_found,
-                requires_impression_event_emission=False,
+                requires_impression_event_emission=bool(
+                    self.should_emit_impression_event(toggle_name)
+                ),
             )
         except Exception:
             result = FeatureVariant(


### PR DESCRIPTION
## Summary

The changes we made to the bindings so that the counting of metrics became internal to the public api exposed that, in order to get the labels of a variant, get_variant is also used internally. That will cause metrics to stop reflecting reality and it's a [no go](https://github.com/Unleash/unleash-python-sdk/pull/406#discussion_r3782327005).

## Solution

The solution to that is to introduce two side-effect-free counterparts to `is_enabled` and `get_variant`: `check_enabled` and `check_variant` respectively.

These two new methods do the exact same thing as the other two with the exception of counting towards metrics.

## Making the implicit explicit

- We know that `check_` is not the best name, however, this pattern (where one method has side effects and the other does not) is already in place in other SDKs. This naming stays consistent with what we already have.
- We argued that the methods that should not have side effects are the `is_` and `get_` versions. We discarded that idea: those two names carry a lot of tribal knowledge. Everyone here expects those two methods to be the entrypoints to our API. It would be a bad move to break that heavy convention in just one of the SDK bindings. We have preferred to just be explicit about the differences between the methods in the docstrings of said methods.